### PR TITLE
Org Chart - Labels and Aside fixes

### DIFF
--- a/src/components/org/OrgChart/components/Aside.tsx
+++ b/src/components/org/OrgChart/components/Aside.tsx
@@ -50,20 +50,20 @@ function Aside<T>() {
         }
     }, [asideRows, rows]);
 
-    const getStartXPosition = (cards: OrgNode<T>[]) => {
+    const getStartXPosition = () => {
         if (numberOfCardsPerRow === 1) {
             if (width < cardWidth * 1.5 + 10) {
                 return width - cardWidth ;
             }
             return cardWidth / 2 + 10;
         }
-        const totalWidth = cards.length * cardWidth + (cards.length - 1) * cardMargin;
-        return centerX - totalWidth / 2;
+        const totalWidth = 2 * cardWidth + cardMargin;
+        return  centerX - totalWidth / 2;
     };
 
     const renderRow = useCallback(
         (cards: OrgNode<T>[], rowNo: number) => {
-            const startX = getStartXPosition(cards);
+            const startX = getStartXPosition();
             return cards.map((card, i) => (
                 <Card
                     key={card.id}

--- a/src/components/org/OrgChart/components/Labels.tsx
+++ b/src/components/org/OrgChart/components/Labels.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 
 const Labels = () => {
     const {
-        state: { allNodes, rowMargin, cardWidth, asideLabel, childrenLabel, centerX, numberOfCardsPerRow },
+        state: { allNodes, rowMargin, cardWidth, asideLabel, childrenLabel, centerX, numberOfCardsPerRow, asideRows, childrenRows },
     } = useContext<OrgChartContextReducer<any>>(OrgChartContext);
 
     const labelRectClassnames = classNames(styles.labelObject, {
@@ -79,8 +79,8 @@ const Labels = () => {
 
     return (
         <g className="label">
-            {asideLabelNode && renderLabel(asideLabelNode)}
-            {childLabelNode && renderLabel(childLabelNode)}
+            {asideLabelNode && asideRows && renderLabel(asideLabelNode)}
+            {childLabelNode && childrenRows && renderLabel(childLabelNode)}
         </g>
     );
 };


### PR DESCRIPTION
Fix for aside when number of aside noes is not an even number and remove labels when no corresponding nodes 