### PR TITLE
UseTooltipRef hook call order

### DIFF
--- a/src/hooks/useTooltipRef/index.tsx
+++ b/src/hooks/useTooltipRef/index.tsx
@@ -20,10 +20,8 @@ export default (
 
     const tooltipClassName = classNames(styles.tooltip, styles[placement.toLocaleLowerCase()]);
 
-    if (!content || content === '') return ref;
-
     useOverlayPortal(
-        isOpen,
+        isOpen && content !== '',
         <div
             className={styles.container}
             style={{


### PR DESCRIPTION
Enured useOverlayProtal hook always will be called in useTooltipRef