### PR TITLE
Remove text decoration URL-button

### DIFF
--- a/src/components/general/Button/styles/index.less
+++ b/src/components/general/Button/styles/index.less
@@ -10,6 +10,7 @@
     cursor: pointer;
     border-radius: var(--corner-radius);
     box-sizing: border-box;
+    text-decoration: none;
 
     & + & {
         margin-left: calc(var(--grid-unit) * 1px) !important;


### PR DESCRIPTION
When sending an URL prop to the button, the button text has underline like a link (see gif). This PR sets the text decoration to none, to remove the underline

![urlbutton](https://user-images.githubusercontent.com/5803429/66296195-5015a600-e8ed-11e9-8441-0933b04b1d2d.gif)
