### PR TITLE
React node as a option to tab title

### DIFF
--- a/src/components/general/Tabs/Tab.tsx
+++ b/src/components/general/Tabs/Tab.tsx
@@ -5,7 +5,7 @@ import { useKeyboardNavigation } from '@equinor/fusion-components';
 
 type TabProps = {
     isCurrent?: boolean;
-    title: string;
+    title: string | React.ReactNode;
     tabKey: string;
     disabled?: boolean;
     onChange?: (ref: HTMLElement) => void;


### PR DESCRIPTION
Allows the user to use custom components as tab title