### PR TITLE
Remove max-width of menu container

### DIFF
--- a/src/components/general/Menu/__stories__/Menu.stories.tsx
+++ b/src/components/general/Menu/__stories__/Menu.stories.tsx
@@ -8,6 +8,27 @@ import { CheckBox, DoneIcon } from '@equinor/fusion-components';
 const MenuStory = () => {
     const [ref, setRef] = React.useState<HTMLElement | null>(null);
 
+    const items = [
+        {
+            key: '1',
+            title: 'First',
+        },
+        {
+            key: '2',
+            title: 'Selected',
+            isSelected: true,
+        },
+        {
+            key: '3',
+            title: 'Disabled',
+            isDisabled: true,
+        },
+        {
+            key: '4',
+            title: 'Last',
+        },
+    ]
+
     return (
         <React.Fragment>
             <input placeholder="Focus here to navigate" ref={setRef} />
@@ -17,29 +38,23 @@ const MenuStory = () => {
                 sections={[
                     {
                         key: 'This is the only section, but I still need a key',
-                        items: [
-                            {
-                                key: '1',
-                                title: 'First',
-                            },
-                            {
-                                key: '2',
-                                title: 'Selected',
-                                isSelected: true,
-                            },
-                            {
-                                key: '3',
-                                title: 'Disabled',
-                                isDisabled: true,
-                            },
-                            {
-                                key: '4',
-                                title: 'Last',
-                            },
-                        ],
+                        items: items,
                     },
                 ]}
             />
+            <div style={{width: '300px'}}>
+                <input placeholder="Narrow menu" ref={setRef} />
+                <Menu
+                    onClick={action('click')}
+                    keyboardNavigationRef={ref}
+                    sections={[
+                        {
+                            key: 'This is the only section, but I still need a key',
+                            items: items,
+                        },
+                    ]}
+                />
+            </div>
         </React.Fragment>
     );
 };

--- a/src/components/general/Menu/styles.less
+++ b/src/components/general/Menu/styles.less
@@ -3,7 +3,6 @@
     border-radius: 4px;
 
     min-width: fit-content;
-    max-width: calc(var(--grid-unit) * 70px);
     margin: 0 0 calc(var(--grid-unit) * 4px) 0;
 
     &:last-child {

--- a/src/components/general/SearchableDropdown/SearchableDropdown.stories.tsx
+++ b/src/components/general/SearchableDropdown/SearchableDropdown.stories.tsx
@@ -110,6 +110,14 @@ const DropdownStory = () => {
                 onSelect={item => updateSections(item)}
                 sections={sections}
             />
+            <br />
+            <div style={{width: '300px'}}>
+                <SearchableDropdown
+                    label="Narrow food"
+                    onSelect={item => updateSections(item)}
+                    sections={sections}
+                />
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
### Issue
After updating the length on SearchableDropdown (https://github.com/equinor/fusion-components/commit/677c7c8720786d20d8793ccda7090a32caed6981), the selectable items in the dropdown menu does not fill the entire width:
![image](https://user-images.githubusercontent.com/5803429/69869665-c4494600-12ad-11ea-8072-93536596ee6c.png)

The SearchableDropdown uses the Menu component, and that component has a max widht of `--grid-unit * 70px`. 

### Suggestion
This pull request removes the max width of the Menu component. **NOTE**: I don't know where this component is used and what it will affect, so this is a suggestion for a solution to the problem
