### PR TITLE
Modale side sheet safe close

### DIFF
--- a/src/components/general/SideSheet/Modal/index.tsx
+++ b/src/components/general/SideSheet/Modal/index.tsx
@@ -50,9 +50,9 @@ export default ({
         if (response.confirmed || response.dismissed) {
             setIsShowing(false);
         }
-    }, []);
+    }, [sendNotification]);
 
-    const close = useCallback(async () => {
+    const close = useCallback(() => {
         if (safeClose) {
             return closeSafe();
         }

--- a/src/components/general/SideSheet/Modal/index.tsx
+++ b/src/components/general/SideSheet/Modal/index.tsx
@@ -20,6 +20,7 @@ type ModalSideSheetProps = {
     headerIcons?: ReactNode[];
     size?: SideSheetSize;
     safeClose?: boolean;
+    safeCloseTitle?: string;
 };
 
 export default ({
@@ -30,6 +31,7 @@ export default ({
     headerIcons,
     size = 'xlarge',
     safeClose,
+    safeCloseTitle
 }: ModalSideSheetProps) => {
     const [isShowing, setIsShowing] = useState(false);
     const sendNotification = useNotificationCenter();
@@ -43,14 +45,14 @@ export default ({
     const closeSafe = useCallback(async () => {
         const response = await sendNotification({
             level: 'high',
-            title: 'Are you sure you want to close, all changes will be lost',
+            title: safeCloseTitle ||'',
             confirmLabel: 'Close',
             cancelLabel: 'Cancel',
         });
         if (response.confirmed || response.dismissed) {
             setIsShowing(false);
         }
-    }, [sendNotification]);
+    }, [sendNotification, safeCloseTitle]);
 
     const close = useCallback(() => {
         if (safeClose) {

--- a/src/components/general/SideSheet/SideSheet.stories.tsx
+++ b/src/components/general/SideSheet/SideSheet.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, select } from '@storybook/addon-knobs';
+import { withKnobs, select, boolean } from '@storybook/addon-knobs';
 import withFusionStory from '../../../../.storybook/withFusionStory';
 import { ModalSideSheet, SideSheet } from './index';
 import { Button, IconButton, WarningIcon, DoneIcon } from '@equinor/fusion-components';
@@ -31,6 +31,7 @@ const ModalSideSheetStory = () => {
                 onClose={() => {
                     setIsOpen(false);
                 }}
+                safeClose={boolean("Safe close", false)}
                 headerIcons={[
                     <IconButton key="Icon1">
                         <WarningIcon outline />


### PR DESCRIPTION
Added a safeClose prop to the modal side sheet. It will notify the user that the closing was intentional before actually closing it