### PR TITLE
SelectedPerson should be handled outside PersonPicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion-components",
-    "version": "0.1.78",
+    "version": "0.1.79",
     "description": "Common react components used by fusion core and fusion apps",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion-components",
-    "version": "0.1.79",
+    "version": "0.1.78",
     "description": "Common react components used by fusion core and fusion apps",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/components/people/PersonPicker/__stories__/PersonPicker.stories.tsx
+++ b/src/components/people/PersonPicker/__stories__/PersonPicker.stories.tsx
@@ -11,7 +11,8 @@ stories.addDecorator(withKnobs);
 stories.addDecorator(withFusionStory('PersonPicker'));
 
 const PreSelectedStory = () => {
-    const [person, setPerson] = useState<PersonDetails>();
+    const [initialPerson, setInitialPerson] = useState<PersonDetails>();
+    const [selectedPerson, setSelectedPerson] = useState<PersonDetails | null>(null);
 
     const context = useFusionContext();
 
@@ -20,9 +21,9 @@ const PreSelectedStory = () => {
             const p = await context.http.apiClients.people.getPersonDetailsAsync(
                 'e92c631b-94ae-4670-8f1e-60cdc2122edc'
             );
-            setPerson(p.data);
+            setInitialPerson(p.data);
         } catch {
-            setPerson(getDefaultPerson());
+            setInitialPerson(getDefaultPerson());
         }
     };
 
@@ -30,16 +31,28 @@ const PreSelectedStory = () => {
         getPersonAsync();
     }, []);
 
-    return <PersonPicker initialPerson={person} label="Selected person" />;
+    return (
+        <PersonPicker
+            initialPerson={initialPerson}
+            selectedPerson={selectedPerson}
+            label="Selected person"
+        />
+    );
 };
 
-stories.add('Default', () => (
-    <>
+const UnselectedStory = () => {
+    const [selectedPerson, setSelectedPerson] = useState<PersonDetails | null>(null);
+
+    return (
         <PersonPicker
             placeholder="Find person"
             hasError={boolean('Show error', false)}
+            selectedPerson={selectedPerson}
+            onSelect={person => setSelectedPerson(person)}
             errorMessage="Required"
         />
-    </>
-));
+    );
+};
+
+stories.add('Default', () => <UnselectedStory />);
 stories.add('Pre Selected', () => <PreSelectedStory />);

--- a/src/components/people/PersonPicker/index.tsx
+++ b/src/components/people/PersonPicker/index.tsx
@@ -21,6 +21,7 @@ type PersonPickerProps = {
     label?: string;
     placeholder?: string;
     initialPerson?: PersonDetails;
+    selectedPerson: PersonDetails | null;
     hasError?: boolean;
     errorMessage?: string;
     onSelect?: (person: PersonDetails) => void;
@@ -62,6 +63,7 @@ const AsideComponent = ({ item }) => {
 
 export default ({
     initialPerson,
+    selectedPerson,
     onSelect,
     hasError,
     errorMessage,
@@ -72,7 +74,6 @@ export default ({
     const [error, isQuerying, people, search] = usePersonQuery();
     const [searchQuery, setSearchQuery] = useState('');
     const [peopleMatch, setPeopleMatch] = useState<PersonDetails[]>([]);
-    const [selectedPersonId, setSelectedPersonId] = useState('');
     const [isInitialized, setInitialized] = useState(false);
 
     useEffect(() => {
@@ -91,15 +92,20 @@ export default ({
 
     useEffect(() => {
         if (isInitialized) {
-            setSections(peopleToSections(peopleMatch, selectedPersonId, searchQuery, isQuerying));
+            setSections(
+                peopleToSections(
+                    peopleMatch,
+                    selectedPerson != null ? selectedPerson.azureUniqueId : '',
+                    searchQuery,
+                    isQuerying
+                )
+            );
         } else {
             setInitialized(searchQuery !== '');
         }
-    }, [peopleMatch, searchQuery, selectedPersonId, isQuerying]);
+    }, [peopleMatch, searchQuery, selectedPerson, isQuerying]);
 
     const handleSelect = useCallback(item => {
-        setSelectedPersonId(item.key);
-
         if (onSelect) {
             onSelect(item.person);
         }


### PR DESCRIPTION
# Motivation
Currently, it is not possible to clear the selected person in the `PersonPicker` component.

# Solution
To solve this, `selectedPerson` is now passed in as a prop and should be handled by the parent component.