### PR TITLE
Move SideSheet resize handle to the right when screen placement is left

### DIFF
--- a/src/components/general/SideSheet/Modal/styles.less
+++ b/src/components/general/SideSheet/Modal/styles.less
@@ -140,6 +140,7 @@
 
     &.isResizing {
         user-select: none;
+        transition: none;
 
         .resizeHandle {
             .bar {

--- a/src/components/general/SideSheet/Standard/index.tsx
+++ b/src/components/general/SideSheet/Standard/index.tsx
@@ -41,7 +41,13 @@ const SideSheet: React.FC<StandardSideSheetProps> = ({
 
     const windowWidth = (window.innerWidth / 3) * 2;
     const { resizedSize, isResizing, onResizeStart } = useResizablePanel(
-        { isResizable: isOpen && isResizable, id, minWidth, maxWidth: Math.min(maxWidth || windowWidth, windowWidth) },
+        {
+            isResizable: isOpen && isResizable,
+            id,
+            minWidth,
+            maxWidth: Math.min(maxWidth || windowWidth, windowWidth),
+            screenPlacement,
+        },
         [size, isOpen]
     );
 

--- a/src/components/general/SideSheet/Standard/styles.less
+++ b/src/components/general/SideSheet/Standard/styles.less
@@ -19,6 +19,15 @@
     &.screenPlacementLeft {
         border-left: none;
         border-right: 2px solid var(--color-black-alt4);
+
+        .header {
+            flex-direction: row-reverse;
+        }
+
+        .resizeHandle {
+            right: calc(var(--grid-unit) * -2px);
+            left: auto;
+        }
     }
 
     &.xlarge {
@@ -82,6 +91,7 @@
     .title {
         font-size: calc(var(--grid-unit) * 3px);
         padding-left: calc(var(--grid-unit) * 2px);
+        flex-grow: 1;
     }
 
     &.isCollapsed {
@@ -141,6 +151,7 @@
 
     &.isResizing {
         user-select: none;
+        transition: none;
 
         .resizeHandle {
             .bar {

--- a/src/components/general/SideSheet/useResizablePanel.ts
+++ b/src/components/general/SideSheet/useResizablePanel.ts
@@ -11,10 +11,11 @@ export interface ResizablePaneOptions {
     id?: string;
     minWidth?: number;
     maxWidth?: number;
+    screenPlacement?: 'right' | 'left';
 }
 
 export default (
-    { isResizable: isEnabled, id, minWidth, maxWidth }: ResizablePaneOptions,
+    { isResizable: isEnabled, id, minWidth, maxWidth, screenPlacement }: ResizablePaneOptions,
     deps?: any[]
 ) => {
     const [appSettings, setAppSettings] = useAppSettings();
@@ -58,7 +59,7 @@ export default (
 
             const mouseEvent = e as MouseEvent;
 
-            const width = window.innerWidth - mouseEvent.pageX;
+            const width = screenPlacement === "left" ? mouseEvent.pageX : window.innerWidth - mouseEvent.pageX;
             const size = getConstrainedSize({ width });
 
             window.requestAnimationFrame(() => setResizedSize(size));
@@ -84,7 +85,9 @@ export default (
             const persistedSize = appSettings[resizeSettingsKey] as ResizedSize;
 
             if (persistedSize && persistedSize.width) {
+                setIsResizing(true);
                 setResizedSize(getConstrainedSize(persistedSize));
+                setTimeout(() => setIsResizing(false), 0);
                 return;
             }
         }


### PR DESCRIPTION
This also removes transition while resizing for smoother experience and avoids animating the width of open panels on initial render