### PR TITLE
Sidesheet initial resizes on mouse move

### DIFF
--- a/src/components/general/SideSheet/Standard/styles.less
+++ b/src/components/general/SideSheet/Standard/styles.less
@@ -70,6 +70,7 @@
        display: flex;
        flex-direction: column;
        overflow: auto;
+       flex-grow: 1;
     }
 
     .header{

--- a/src/components/general/SideSheet/useResizablePanel.ts
+++ b/src/components/general/SideSheet/useResizablePanel.ts
@@ -43,10 +43,8 @@ export default (
             const actualMinWidth = minWidth || 150;
 
             if (width > actualMaxWidth) {
-                console.log("CONSTRAINING SIZE MAX", actualMaxWidth);
                 return { width: actualMaxWidth };
             } else if (width < actualMinWidth) {
-                console.log("CONSTRAINING SIZE MIN", actualMinWidth);
                 return { width: actualMinWidth };
             }
 
@@ -90,7 +88,6 @@ export default (
             const persistedSize = appSettings[resizeSettingsKey] as ResizedSize;
 
             if (persistedSize && persistedSize.width) {
-                console.log("SETTING SIZE", persistedSize.width);
                 setIsResizing(true);
                 setResizedSize(getConstrainedSize(persistedSize));
                 setTimeout(() => setIsResizing(false), 0);

--- a/src/components/general/SideSheet/useResizablePanel.ts
+++ b/src/components/general/SideSheet/useResizablePanel.ts
@@ -21,12 +21,14 @@ export default (
     const [appSettings, setAppSettings] = useAppSettings();
     const resizeSettingsKey = id && `${id}.size`;
     const [isResizing, setIsResizing] = useState(false);
+    const [mouseIsDown, setMouseIsDown] = useState(false);
     const [resizedSize, setResizedSize] = useState<ResizedSize | null>(null);
 
     const onResizeStart = useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
             if (isEnabled) {
                 setIsResizing(true);
+                setMouseIsDown(true);
             }
         },
         [isEnabled]
@@ -41,8 +43,10 @@ export default (
             const actualMinWidth = minWidth || 150;
 
             if (width > actualMaxWidth) {
+                console.log("CONSTRAINING SIZE MAX", actualMaxWidth);
                 return { width: actualMaxWidth };
             } else if (width < actualMinWidth) {
+                console.log("CONSTRAINING SIZE MIN", actualMinWidth);
                 return { width: actualMinWidth };
             }
 
@@ -53,7 +57,7 @@ export default (
 
     const onResize = useCallback(
         (e: Event) => {
-            if (!isResizing) {
+            if (!isResizing || !mouseIsDown) {
                 return;
             }
 
@@ -69,6 +73,7 @@ export default (
 
     const onResizeEnd = useCallback(() => {
         if (isResizing) {
+            setMouseIsDown(false);
             setTimeout(() => setIsResizing(false));
 
             if (resizeSettingsKey && resizedSize) {
@@ -85,6 +90,7 @@ export default (
             const persistedSize = appSettings[resizeSettingsKey] as ResizedSize;
 
             if (persistedSize && persistedSize.width) {
+                console.log("SETTING SIZE", persistedSize.width);
                 setIsResizing(true);
                 setResizedSize(getConstrainedSize(persistedSize));
                 setTimeout(() => setIsResizing(false), 0);


### PR DESCRIPTION
## Problem
When setting the initial size of a sidesheet, the `isResizing` flag is set to true to allow sidesheets to disable animations for smoother renders, but if the user moves the mouse while setting the initial size the onResize handler will trigger and resize the sidesheet

## Solution
Split `isResizing` into `isResizing` and `isMouseDown`. When the user is resizing, both `isResizing` and `isMouseDown` is set to **true**, but when programatically resizing (initial render with size from local storage) only `isResizing` is set to true