### PR TITLE
UI improvements to FilterPane and DataTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9276,7 +9276,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -9297,12 +9298,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -9317,17 +9320,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -9444,7 +9450,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -9456,6 +9463,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -9470,6 +9478,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -9477,12 +9486,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -9501,6 +9512,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -9581,7 +9593,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -9593,6 +9606,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -9678,7 +9692,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -9714,6 +9729,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -9733,6 +9749,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -9776,12 +9793,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/src/components/data/DataTable/styles.less
+++ b/src/components/data/DataTable/styles.less
@@ -99,8 +99,7 @@
 
         li {
             margin: 0;
-            padding: calc(var(--grid-unit) * var(--list-vertical-padding-multiplier)) 0;
-            border-bottom: 1px solid var(--border-color);
+            padding: 0;
         }
     }
 

--- a/src/components/general/FilterPane/index.tsx
+++ b/src/components/general/FilterPane/index.tsx
@@ -36,7 +36,7 @@ export type FilterPaneProps<T> = {
     terms: FilterTerm[];
     onChange: OnFilterChangeHandler<T>;
     screenPlacement?: 'right' | 'left';
-    onToggleCollapse?:(isCollapsed: boolean) => void;
+    onToggleCollapse?: (isCollapsed: boolean) => void;
 };
 
 function FilterPane<T>({
@@ -46,7 +46,7 @@ function FilterPane<T>({
     terms,
     onChange,
     screenPlacement = 'right',
-    onToggleCollapse
+    onToggleCollapse,
 }: FilterPaneProps<T>) {
     const [isCollapsed, setIsCollapsed] = useState(getDefaultCollapsed(id));
     const [filterCount, setFilterCount] = useState<Count[]>([]);
@@ -102,16 +102,22 @@ function FilterPane<T>({
     return (
         <FilterPaneContext.Provider value={filterPaneContext}>
             <div className={containerClassNames}>
-                <CollapseExpandButton onClick={toggleCollapsed} />
-                {sectionDefinitions.map(section => (
-                    <Section
-                        key={section.key}
-                        section={section}
-                        terms={terms}
-                        filterCount={filterCount}
-                        onChange={handleOnSectionChange}
-                    />
-                ))}
+                <div className={styles.header}>
+                    <div className={styles.collapseExpandButtonContainer}>
+                        <CollapseExpandButton onClick={toggleCollapsed} />
+                    </div>
+                </div>
+                <div className={styles.content}>
+                    {sectionDefinitions.map(section => (
+                        <Section
+                            key={section.key}
+                            section={section}
+                            terms={terms}
+                            filterCount={filterCount}
+                            onChange={handleOnSectionChange}
+                        />
+                    ))}
+                </div>
             </div>
         </FilterPaneContext.Provider>
     );

--- a/src/components/general/FilterPane/styles.less
+++ b/src/components/general/FilterPane/styles.less
@@ -107,6 +107,8 @@
 
     &.compact {
 
+        width: calc(var(--grid-unit) * 37px);
+
         &.isCollapsed {
             .content {
                 padding: 0;
@@ -120,7 +122,6 @@
 
         .content {
             padding: calc(var(--grid-unit) * 1px);
-            width: calc(var(--grid-unit) * 37px);
 
             section {
                 padding-bottom: calc(var(--grid-unit) * 1px);
@@ -181,6 +182,8 @@
 
     &.comfortable {
 
+        width: calc(var(--grid-unit) * 39px);
+
         &.isCollapsed {
             .content {
                 padding: 0;
@@ -189,7 +192,6 @@
 
         .content {
             padding: calc(var(--grid-unit) * 2px);
-            width: calc(var(--grid-unit) * 39px);
 
             section {
                 padding-bottom: calc(var(--grid-unit) * 2px);

--- a/src/components/general/FilterPane/styles.less
+++ b/src/components/general/FilterPane/styles.less
@@ -11,32 +11,27 @@
     &.screenPlacementLeft {
         border-left: none;
         border-right: 2px solid var(--color-black-alt4);
+
+        .header {
+            flex-direction: row-reverse;
+        }
     }
 
-    .collapseExpandButton {
+    .header{
         display: flex;
         align-items: center;
+        overflow: hidden;
+        flex-shrink: 0;
+        padding: 0;
+    }
+
+    .collapseExpandButtonContainer {
+        width: calc(var(--grid-unit) * 6px);
+        height: calc(var(--grid-unit) * 6px);
+        border-bottom: 1px solid var(--color-black-alt4);
+        display: flex;
         justify-content: center;
-        background: none;
-        border: none;
-        outline: none;
-        width: calc(var(--grid-unit) * 4px);
-        height: calc(var(--grid-unit) * 4px);
-        cursor: pointer;
-
-        svg {
-            path {
-                fill: var(--color-primary-accent);
-            }
-        }
-
-        &:hover {
-            svg {
-                path {
-                    fill: var(--color-primary);
-                }
-            }
-        }
+        align-items: center;
     }
 
     section {
@@ -111,58 +106,72 @@
     }
 
     &.compact {
-        padding: calc(var(--grid-unit) * 1px);
-        width: calc(var(--grid-unit) * 37px);
 
-        section {
-            padding-bottom: calc(var(--grid-unit) * 1px);
-            margin-bottom: calc(var(--grid-unit) * 2px);
-
-            &:first-of-type {
-                margin-top: calc(var(--grid-unit) * 1px);
+        &.isCollapsed {
+            .content {
+                padding: 0;
             }
+        }
 
-            &.isCollapsed {
-                padding-bottom: 0;
-            }
+        .collapseExpandButtonContainer {
+            width: calc(var(--grid-unit) * 4px);
+            height: calc(var(--grid-unit) * 4px);
+        }
 
-            &.hasTitle {
-                .filter {
-                    margin-left: calc(var(--grid-unit) * 1px);
-                }
-            }
+        .content {
+            padding: calc(var(--grid-unit) * 1px);
+            width: calc(var(--grid-unit) * 37px);
 
-            header {
-                h3 {
-                    font-size: 12px;
-                }
-            }
-
-            .filter {
+            section {
                 padding-bottom: calc(var(--grid-unit) * 1px);
                 margin-bottom: calc(var(--grid-unit) * 2px);
 
-                &:last-child {
-                    padding-bottom: 0;
-                    margin-bottom: 0;
+                &:first-of-type {
+                    margin-top: calc(var(--grid-unit) * 1px);
                 }
 
                 &.isCollapsed {
                     padding-bottom: 0;
                 }
 
-                header {
-                    h4 {
-                        font-size: 11px;
-                        font-weight: 400;
+                &.hasTitle {
+                    .filter {
+                        margin-left: calc(var(--grid-unit) * 1px);
                     }
                 }
 
-                ul {
-                    li {
-                        > label {
-                            margin-left: calc(var(--grid-unit) * 1px);
+                header {
+                    h3 {
+                        font-size: 12px;
+                    }
+                }
+
+                .filter {
+                    padding-bottom: calc(var(--grid-unit) * 1px);
+                    margin-bottom: calc(var(--grid-unit) * 2px);
+
+                    &:last-child {
+                        padding-bottom: 0;
+                        margin-bottom: 0;
+                    }
+
+                    &.isCollapsed {
+                        padding-bottom: 0;
+                    }
+
+                    header {
+                        h4 {
                             font-size: 11px;
+                            font-weight: 400;
+                        }
+                    }
+
+                    ul {
+                        li {
+                            > label {
+                                margin-left: calc(var(--grid-unit) * 1px);
+                                font-size: 11px;
+                            }
                         }
                     }
                 }
@@ -171,61 +180,67 @@
     }
 
     &.comfortable {
-        padding: calc(var(--grid-unit) * 2px);
-        width: calc(var(--grid-unit) * 39px);
-        
-        &.isCollapsed{
-            padding: 0;
+
+        &.isCollapsed {
+            .content {
+                padding: 0;
+            }
         }
-        section {
-            padding-bottom: calc(var(--grid-unit) * 2px);
-            margin-bottom: calc(var(--grid-unit) * 4px);
 
-            &:first-of-type {
-                margin-top: calc(var(--grid-unit) * 1px);
-            }
+        .content {
+            padding: calc(var(--grid-unit) * 2px);
+            width: calc(var(--grid-unit) * 39px);
 
-            &.isCollapsed {
-                padding-bottom: 0;
-            }
-
-            &.hasTitle {
-                .filter {
-                    margin-left: calc(var(--grid-unit) * 2px);
-                }
-            }
-
-            header {
-                h3 {
-                    font-size: 14px;
-                }
-            }
-
-            .filter {
+            section {
                 padding-bottom: calc(var(--grid-unit) * 2px);
                 margin-bottom: calc(var(--grid-unit) * 4px);
 
-                &:last-child {
-                    padding-bottom: 0;
-                    margin-bottom: 0;
+                &:first-of-type {
+                    margin-top: calc(var(--grid-unit) * 1px);
                 }
 
                 &.isCollapsed {
                     padding-bottom: 0;
                 }
 
-                header {
-                    h4 {
-                        font-size: 12px;
-                        font-weight: 400;
+                &.hasTitle {
+                    .filter {
+                        margin-left: calc(var(--grid-unit) * 2px);
                     }
                 }
 
-                ul {
-                    li {
-                        > label {
-                            margin-left: calc(var(--grid-unit) * 1px);
+                header {
+                    h3 {
+                        font-size: 14px;
+                    }
+                }
+
+                .filter {
+                    padding-bottom: calc(var(--grid-unit) * 2px);
+                    margin-bottom: calc(var(--grid-unit) * 4px);
+
+                    &:last-child {
+                        padding-bottom: 0;
+                        margin-bottom: 0;
+                    }
+
+                    &.isCollapsed {
+                        padding-bottom: 0;
+                    }
+
+                    header {
+                        h4 {
                             font-size: 12px;
+                            font-weight: 400;
+                        }
+                    }
+
+                    ul {
+                        li {
+                            > label {
+                                margin-left: calc(var(--grid-unit) * 1px);
+                                font-size: 12px;
+                            }
                         }
                     }
                 }
@@ -234,12 +249,17 @@
     }
 
     &.isCollapsed {
-        width: auto;
+
+        .content {
+            width: auto;
+        }
 
         &.compact, &.comfortable {
-            section {
-                .filter {
-                    margin-left: 0;
+            .content {
+                section {
+                    .filter {
+                        margin-left: 0;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Changes
This PR includes a couple of UI improvements to the `FilterPane` and `DataTable` components.

### Filter Pane
The Filter Pane UI is not consistent with the `StandardSideSheet` component. If the `screenPlacement` is set to `left`, the collapse button would still render on the left side of the filter pane. The position of the button now respects the screen placement property.

I also created a new css class for the filter pane content so that the header containing the expand/collapse button would not get affected by the content padding. This makes it consistent with the standard side sheet. See example below.

Existing:
![image](https://user-images.githubusercontent.com/3788207/71990015-f8137600-3232-11ea-917e-fddf8278ae96.png)
New:
![image](https://user-images.githubusercontent.com/3788207/72049830-0fe50b80-32c0-11ea-8179-a27203df2f8a.png)

### Data Table
If users of the `DataTable` component would like to render a custom component when there is not enough space for the table, a `listComponent` can be provided. The list component however, is rendered with padding and a bottom border for each item in the list. This should not be enforced by the data table, but rather be defined in the custom list component. An example of the enforced styles can be seen below.
![image](https://user-images.githubusercontent.com/3788207/71989880-bb477f00-3232-11ea-807d-81e671cda4df.png)
