### PR TITLE
Add support for rendering the fusion root and container without the fusion header

### DIFF
--- a/src/components/core/Container/index.tsx
+++ b/src/components/core/Container/index.tsx
@@ -3,12 +3,20 @@ import classNames from 'classnames';
 import { useComponentDisplayClassNames } from '@equinor/fusion';
 import styles from './styles.less';
 
-type FusionContainerProps = {};
+type FusionContainerProps = {
+    noHeader?: boolean;
+};
 
-const FusionContainer = React.forwardRef<HTMLDivElement, React.Props<FusionContainerProps>>(
-    ({ children }, ref) => {
-        const containerClassNames = classNames(styles.container, useComponentDisplayClassNames(styles));
-        
+const FusionContainer = React.forwardRef<HTMLDivElement, React.PropsWithChildren<FusionContainerProps>>(
+    ({ noHeader = false, children }, ref) => {
+        const containerClassNames = classNames(
+            styles.container,
+            useComponentDisplayClassNames(styles),
+            {
+                [styles.noHeader]: noHeader,
+            }
+        );
+
         return (
             <div className={containerClassNames} ref={ref}>
                 {children}

--- a/src/components/core/Container/styles.less
+++ b/src/components/core/Container/styles.less
@@ -19,4 +19,9 @@
         --header-height: calc((var(--grid-unit) * 6px) + 2px);
         grid-template-rows: var(--header-height) calc(100% - var(--header-height));
     }
+
+    &.noHeader {
+        --header-height: 0px;
+        grid-template-rows: 0px calc(100% - var(--header-height));
+    }
 }

--- a/src/components/core/Root/index.tsx
+++ b/src/components/core/Root/index.tsx
@@ -10,11 +10,12 @@ import classNames from 'classnames';
 type FusionRootProps = {
     rootRef: React.MutableRefObject<HTMLElement | null>;
     overlayRef: React.MutableRefObject<HTMLElement | null>;
+    noHeader?: boolean;
 };
 
-const FusionRoot: React.FC<FusionRootProps> = ({ children, rootRef, overlayRef }) => (
+const FusionRoot: React.FC<FusionRootProps> = ({ children, rootRef, overlayRef, noHeader = false }) => (
     <div className={classNames(styles.container, useComponentDisplayClassNames(styles))}>
-        <FusionContainer ref={rootRef as React.MutableRefObject<HTMLDivElement>}>
+        <FusionContainer ref={rootRef as React.MutableRefObject<HTMLDivElement>} noHeader={noHeader}>
             {children}
         </FusionContainer>
         <div


### PR DESCRIPTION
## Problem
The fusion container uses css grid layout to create seperate areas for the main header and the content. If the container is rendered without a header the area where the header should go is empty, not gone.

## Solution
Introduce props to the root component to tell fusion to render with or without header