### PR TITLE
Check for breakpoints that are _not_ in the current breakpoints

### DIFF
--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, MutableRefObject } from 'react';
-import { enqueueAsyncOperation } from "@equinor/fusion";
+import { enqueueAsyncOperation } from '@equinor/fusion';
 
 export type Breakpoint = {
     key: string;
@@ -33,7 +33,10 @@ const useBreakpoint = (
 
             const nodeRect = nodeRef.current.getBoundingClientRect();
             const breakpoints = checkSize(nodeRect);
-            if(breakpoints.length !== currentBreakpoints.length || breakpoints.filter(b => currentBreakpoints.indexOf(b) > -1).length > 0) {
+            if (
+                breakpoints.length !== currentBreakpoints.length ||
+                breakpoints.filter(b => currentBreakpoints.indexOf(b) === -1).length > 0
+            ) {
                 setCurrentBreakpoints(breakpoints);
             }
             performCheckSize(abortSignal);


### PR DESCRIPTION
A bug where useBreakpoint would continuously rerender all components using it as long as the current and new breakpoint are the same