### PR TITLE
Bugfix/hide tooltip when node removed

### DIFF
--- a/src/hooks/useHoverToggleController.ts
+++ b/src/hooks/useHoverToggleController.ts
@@ -1,6 +1,5 @@
-import { useRef, useState, MutableRefObject, useCallback } from 'react';
+import { useRef, useState, MutableRefObject, useCallback, useEffect } from 'react';
 import { useEventListener } from '@equinor/fusion-components';
-import { Recoverable } from 'repl';
 
 let showTimeout: NodeJS.Timeout;
 export default <T extends HTMLElement>(
@@ -14,36 +13,28 @@ export default <T extends HTMLElement>(
         showTimeout = setTimeout(() => setIsHovering(true), delay);
     }, [delay]);
 
-    const hide = () => {
+    const hide = useCallback(() => {
         clearTimeout(showTimeout);
         setIsHovering(false);
-    };
+    }, []);
 
     const checkShouldShow = useCallback(
         (e: Event) => {
             if (!ref.current || !e.target) {
-                if(isHovering) {
+                if (isHovering) {
+                    console.log('Hide');
                     hide();
                 }
-                
+
                 return;
             }
-
-            const target = e.target as Node;
-            const isWithinRef = ref.current.isSameNode(target);
-
-            if (isWithinRef && !isHovering) {
-                show();
-            } else if (!isWithinRef && isHovering) {
-                hide();
-            }
         },
-        [show, ref.current, isHovering]
+        [hide, ref.current, isHovering]
     );
 
     useEventListener(ref.current, 'mouseenter', show, [ref.current]);
     useEventListener(ref.current, 'mouseleave', hide, [ref.current]);
-    useEventListener(window, 'mousemove', checkShouldShow, []);
+    useEventListener(window, 'mousemove', checkShouldShow, [checkShouldShow]);
 
     return [isHovering, ref];
 };

--- a/src/hooks/useHoverToggleController.ts
+++ b/src/hooks/useHoverToggleController.ts
@@ -1,38 +1,43 @@
-import { useRef, useState, MutableRefObject, useCallback, useEffect } from 'react';
+import { useRef, useState, MutableRefObject, useCallback } from 'react';
 import { useEventListener } from '@equinor/fusion-components';
-
-let showTimeout: NodeJS.Timeout;
 export default <T extends HTMLElement>(
     delay: number = 300
 ): [boolean, MutableRefObject<T | null>] => {
     const [isHovering, setIsHovering] = useState<boolean>(false);
     const ref = useRef<T | null>(null);
+    const timer = useRef<NodeJS.Timeout>();
 
     const show = useCallback(() => {
-        clearTimeout(showTimeout);
-        showTimeout = setTimeout(() => setIsHovering(true), delay);
-    }, [delay]);
+        if (timer.current) clearTimeout(timer.current);
+        timer.current = setTimeout(() => setIsHovering(true), delay);
+    }, [delay, timer.current]);
 
     const hide = useCallback(() => {
-        clearTimeout(showTimeout);
-        setIsHovering(false);
-    }, []);
+        if (timer.current) clearTimeout(timer.current);
+        if (isHovering) {
+            setIsHovering(false);
+        }
+    }, [isHovering, timer.current]);
 
     const checkShouldShow = useCallback(
         (e: Event) => {
-            if (!ref.current || !e.target) {
-                if (isHovering) {
-                    hide();
-                }
-
+            if (!ref.current) {
+                hide();
                 return;
             }
+            const mouseEvent = e as MouseEvent;
+            const hoveredElement = document.elementFromPoint(mouseEvent.pageX, mouseEvent.pageY);
+            const isWithinRef =
+                ref.current == hoveredElement || ref.current.contains(hoveredElement);
+            if (isWithinRef && !isHovering) {
+                show();
+            } else if (!isWithinRef) {
+                hide();
+            }
         },
-        [hide, ref.current, isHovering]
+        [show, hide, ref.current, isHovering]
     );
 
-    useEventListener(ref.current, 'mouseenter', show, [ref.current]);
-    useEventListener(ref.current, 'mouseleave', hide, [ref.current]);
     useEventListener(window, 'mousemove', checkShouldShow, [checkShouldShow]);
 
     return [isHovering, ref];

--- a/src/hooks/useHoverToggleController.ts
+++ b/src/hooks/useHoverToggleController.ts
@@ -22,7 +22,6 @@ export default <T extends HTMLElement>(
         (e: Event) => {
             if (!ref.current || !e.target) {
                 if (isHovering) {
-                    console.log('Hide');
                     hide();
                 }
 


### PR DESCRIPTION
Fixes a bug where the tooltip was still visible after the element with the tooltip ref was not rendered anymore.

Example: Render an element with a button that has a tooltip => the buttons `onClick` function results in the element not being rendered anymore => button tooltip is still visible until page reload...

Part of the solution was to add `checkShouldShow` to the dependency array of the `mousemove` listener, but that made the tooltip hide unintentionally. That happened because `ref.current.isSameNode(target)` would only return `true` when the mouse entered the node, and `false` when moving the mouse inside the node.

As far as I can see, this is already covered by the `mouseenter` and `mouseleave` handlers, so I removed those checks from `checkShouldShow` altogether.