### PR TITLE
Fixes problem where multiple tooltips was rendered on top of each other

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29222,7 +29222,7 @@
                     "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
                     "dev": true,
                     "requires": {
-                        "esutils": "2.0.2"
+                        "esutils": "^2.0.2"
                     }
                 },
                 "source-map": {
@@ -33406,29 +33406,29 @@
                     "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
                     "dev": true,
                     "requires": {
-                        "assert": "1.5.0",
-                        "browserify-zlib": "0.2.0",
-                        "buffer": "4.9.1",
-                        "console-browserify": "1.1.0",
-                        "constants-browserify": "1.0.0",
-                        "crypto-browserify": "3.12.0",
-                        "domain-browser": "1.2.0",
-                        "events": "3.0.0",
-                        "https-browserify": "1.0.0",
-                        "os-browserify": "0.3.0",
+                        "assert": "^1.1.1",
+                        "browserify-zlib": "^0.2.0",
+                        "buffer": "^4.3.0",
+                        "console-browserify": "^1.1.0",
+                        "constants-browserify": "^1.0.0",
+                        "crypto-browserify": "^3.11.0",
+                        "domain-browser": "^1.1.1",
+                        "events": "^3.0.0",
+                        "https-browserify": "^1.0.0",
+                        "os-browserify": "^0.3.0",
                         "path-browserify": "0.0.1",
-                        "process": "0.11.10",
-                        "punycode": "1.4.1",
-                        "querystring-es3": "0.2.1",
-                        "readable-stream": "2.3.6",
-                        "stream-browserify": "2.0.2",
-                        "stream-http": "2.8.3",
-                        "string_decoder": "1.2.0",
-                        "timers-browserify": "2.0.10",
+                        "process": "^0.11.10",
+                        "punycode": "^1.2.4",
+                        "querystring-es3": "^0.2.0",
+                        "readable-stream": "^2.3.3",
+                        "stream-browserify": "^2.0.1",
+                        "stream-http": "^2.7.2",
+                        "string_decoder": "^1.0.0",
+                        "timers-browserify": "^2.0.4",
                         "tty-browserify": "0.0.0",
-                        "url": "0.11.0",
-                        "util": "0.11.1",
-                        "vm-browserify": "1.1.0"
+                        "url": "^0.11.0",
+                        "util": "^0.11.0",
+                        "vm-browserify": "^1.0.1"
                     },
                     "dependencies": {
                         "vm-browserify": {

--- a/src/hooks/useHoverToggleController.ts
+++ b/src/hooks/useHoverToggleController.ts
@@ -1,43 +1,38 @@
-import { useRef, useState, MutableRefObject, useCallback } from 'react';
+import { useRef, useState, MutableRefObject, useCallback, useEffect } from 'react';
 import { useEventListener } from '@equinor/fusion-components';
+
+let showTimeout: NodeJS.Timeout;
 export default <T extends HTMLElement>(
     delay: number = 300
 ): [boolean, MutableRefObject<T | null>] => {
     const [isHovering, setIsHovering] = useState<boolean>(false);
     const ref = useRef<T | null>(null);
-    const timer = useRef<NodeJS.Timeout>();
 
     const show = useCallback(() => {
-        if (timer.current) clearTimeout(timer.current);
-        timer.current = setTimeout(() => setIsHovering(true), delay);
-    }, [delay, timer.current]);
+        clearTimeout(showTimeout);
+        showTimeout = setTimeout(() => setIsHovering(true), delay);
+    }, [delay]);
 
     const hide = useCallback(() => {
-        if (timer.current) clearTimeout(timer.current);
-        if (isHovering) {
-            setIsHovering(false);
-        }
-    }, [isHovering, timer.current]);
+        clearTimeout(showTimeout);
+        setIsHovering(false);
+    }, []);
 
     const checkShouldShow = useCallback(
         (e: Event) => {
-            if (!ref.current) {
-                hide();
+            if (!ref.current || !e.target) {
+                if (isHovering) {
+                    hide();
+                }
+
                 return;
             }
-            const mouseEvent = e as MouseEvent;
-            const hoveredElement = document.elementFromPoint(mouseEvent.pageX, mouseEvent.pageY);
-            const isWithinRef =
-                ref.current == hoveredElement || ref.current.contains(hoveredElement);
-            if (isWithinRef && !isHovering) {
-                show();
-            } else if (!isWithinRef) {
-                hide();
-            }
         },
-        [show, hide, ref.current, isHovering]
+        [hide, ref.current, isHovering]
     );
 
+    useEventListener(ref.current, 'mouseenter', show, [ref.current]);
+    useEventListener(ref.current, 'mouseleave', hide, [ref.current]);
     useEventListener(window, 'mousemove', checkShouldShow, [checkShouldShow]);
 
     return [isHovering, ref];


### PR DESCRIPTION
In the example below (`PersonPhoto`), 3 tooltips/popovers are show at the same time.
This bug was introduced in #230.
![image](https://user-images.githubusercontent.com/3788207/74039329-ec49d980-49c1-11ea-898d-5807c7ac0d44.png)

The changes in this PR fixes most of the problems, but there is still a problem if you move the pointer over to the smaller circle to see the persons position, and then move it over to the photo to see more details. The move from the small circle to the bigger circle is not detected. Any thoughts on how we can fix this problem would be appreciated. However, I think it is better than the current version. 
![image](https://user-images.githubusercontent.com/3788207/74039493-359a2900-49c2-11ea-9f57-9d3a2021a23a.png)
