### PR TITLE
Reapply filter when clicking on "reset filter"

### DIFF
--- a/src/components/data/PowerBIReport/index.tsx
+++ b/src/components/data/PowerBIReport/index.tsx
@@ -23,6 +23,7 @@ import {
 } from './models/ReportLevelFilters';
 
 import * as styles from './styles.less';
+import { ButtonClickEvent } from './models/EventHandlerTypes';
 
 type PowerBIProps = {
     reportId: string;
@@ -198,8 +199,12 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters }) => {
     React.useEffect(() => {
         if (embeddedRef.current) {
             embeddedRef.current.off('pageChanged');
+            embeddedRef.current.off('buttonClicked');
             embeddedRef.current.on('pageChanged', () => {
                 setFilter();
+            });
+            embeddedRef.current.on('buttonClicked', (button: ICustomEvent<ButtonClickEvent>) => {
+                if (button.detail.title === 'reset filter') setFilter();
             });
         }
     }, [filters, embedRef.current]);

--- a/src/components/data/PowerBIReport/index.tsx
+++ b/src/components/data/PowerBIReport/index.tsx
@@ -204,7 +204,7 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters }) => {
                 setFilter();
             });
             embeddedRef.current.on('buttonClicked', (button: ICustomEvent<ButtonClickEvent>) => {
-                if (button.detail.title === 'reset filter') setFilter();
+                if (button.detail.title.toLowerCase() === 'reset filter') setFilter();
             });
         }
     }, [filters, embedRef.current]);

--- a/src/components/data/PowerBIReport/models/EventHandlerTypes.ts
+++ b/src/components/data/PowerBIReport/models/EventHandlerTypes.ts
@@ -1,0 +1,6 @@
+export type ButtonClickEvent = {
+    id: string;
+    title?: string;
+    type?: string;
+    bookmark?: string;
+};


### PR DESCRIPTION
When user clicks on the "reset filter" button all filters are removed from the report. 
Including selected context.  Removing context should not be possible. 

A onClickButtonClick event handler has been added to handle this problem.
If reset button is clicked filter will be reapplied to report. 

