### PR TITLE
Position card - Timeline color change for rotation. Cumulative child support

### DIFF
--- a/src/components/org/PositionCard/PositionCard.stories.tsx
+++ b/src/components/org/PositionCard/PositionCard.stories.tsx
@@ -293,9 +293,11 @@ const InteractiveStory = () => {
             isSelected={isSelected}
             onExpand={action('onExpand')}
             childCount={number('Child count', 2)}
+            cumulativeChildCount={number('Cumulative child count', 2)}
             isFuture={boolean('Show as future position', false)}
             isPast={boolean('Show as past position', false)}
             selectedDate={new Date('2022-09-25T00:00:00')}
+
         />
     );
 };

--- a/src/components/org/PositionCard/components/PositionInstance.tsx
+++ b/src/components/org/PositionCard/components/PositionInstance.tsx
@@ -16,8 +16,9 @@ type PositionInstanceProps = {
     onClick?: (position: Position, instance?: PositionInstance) => void;
     onExpand?: (position: Position, instance?: PositionInstance) => void;
     childCount?: number;
+    cumulativeChildCount?: number;
     rotationInstances: PositionInstance[];
-    selectedDate?: Date,
+    selectedDate?: Date;
 };
 
 const PositionInstanceComponent: React.FC<PositionInstanceProps> = ({
@@ -31,6 +32,7 @@ const PositionInstanceComponent: React.FC<PositionInstanceProps> = ({
     onClick,
     onExpand,
     childCount,
+    cumulativeChildCount,
     rotationInstances,
     selectedDate,
 }) => {
@@ -48,7 +50,18 @@ const PositionInstanceComponent: React.FC<PositionInstanceProps> = ({
     const positionNameTooltipRef = useTooltipRef('Position: ' + position.name, 'below');
     const assignedPersonNameTooltipRef = useTooltipRef('Person: ' + assignedPersonName, 'below');
     const currentPeriodTooltipRef = useTooltipRef('Current period', 'below');
-    const directChildrenTooltipRef = useTooltipRef(`${childCount} positions`, 'above');
+    const directChildrenTooltipRef = useTooltipRef(
+        <span>
+            Direct: {childCount} positions
+            {cumulativeChildCount && (
+                <>
+                    <br />
+                    Cumulative: {cumulativeChildCount} positions
+                </>
+            )}
+        </span>,
+        'above'
+    );
     const externalIdTooltipRef = useTooltipRef('External ID: ' + position.externalId, 'below');
 
     const positionInstanceClasses = classNames(styles.positionInstance, {
@@ -125,7 +138,7 @@ const PositionInstanceComponent: React.FC<PositionInstanceProps> = ({
                 <div className={styles.expandButton}>
                     <IconButton ref={directChildrenTooltipRef} onClick={onExpandHandler}>
                         <div className={styles.childPositionCount}>
-                            {childCount}
+                            {childCount} {cumulativeChildCount && <>/ {cumulativeChildCount} </>}
                             <ExpandMoreIcon height={16} isExpanded={false} />
                         </div>
                     </IconButton>

--- a/src/components/org/PositionCard/components/PositionTimeline.tsx
+++ b/src/components/org/PositionCard/components/PositionTimeline.tsx
@@ -85,6 +85,7 @@ const TimelineInstance: React.FC<TimelineInstanceProps> = ({
     const timelineInstanceClasses = classNames(styles.instance, {
         [styles.isCurrent]: isCurrent,
         [styles.hasUnAssignedPerson]: instance.assignedPerson === null,
+        [styles.hasRotation]: rotationInstances.length > 0
     });
 
     const shouldRenderRightDot = useMemo(() => {

--- a/src/components/org/PositionCard/index.tsx
+++ b/src/components/org/PositionCard/index.tsx
@@ -20,6 +20,7 @@ type PositionCardProps = {
     isPast?: boolean;
     isLinked?: boolean;
     childCount?: number;
+    cumulativeChildCount?: number;
     selectedDate?: Date;
     onClick?: (position: Position, instance?: PositionInstance) => void;
     onExpand?: (position: Position, instance?: PositionInstance) => void;
@@ -40,6 +41,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
     isPast,
     isLinked,
     childCount,
+    cumulativeChildCount,
     selectedDate,
 }) => {
     const isExternalHire =
@@ -102,6 +104,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
                 onClick={onClick}
                 onExpand={onExpand}
                 childCount={childCount}
+                cumulativeChildCount={cumulativeChildCount}
                 rotationInstances={rotatingInstances}
                 selectedDate={selectedDate}
             />

--- a/src/components/org/PositionCard/styles.less
+++ b/src/components/org/PositionCard/styles.less
@@ -224,9 +224,15 @@
                 
                 &.isCurrent {
                     --instance-color: var(--color-primary);
+                    &.hasRotation {
+                        --instance-color: var(--color-secondary-alt1);
+                    }
                 }
                 &:not(.isCurrent){
                     --instance-color: var(--color-primary-alt1);
+                    &.hasRotation {
+                        --instance-color: var(--color-secondary-alt3);
+                    }
                 }
 
                 &.hasUnAssignedPerson {


### PR DESCRIPTION
When a position has rotation, a pink color is added to the position card timeline to increase visibility.

Added a option to position card to show cumulative child count