### PR TITLE
Pass header content as a functional component

### DIFF
--- a/src/components/core/ContextSelector/__stories__/ContextSelector.stories.tsx
+++ b/src/components/core/ContextSelector/__stories__/ContextSelector.stories.tsx
@@ -49,7 +49,7 @@ const PDPContextSelectorStory = () => {
     return (
         <React.Fragment>
             <CurrentContext>
-                <FusionHeader start={null} content={<ContextSelector />} aside={null} />
+                <FusionHeader start={null} content={ContextSelector} aside={null} />
                 <FusionContent>
                     <h1 style={{ textAlign: 'center', margin: 16 }}>PDP</h1>
                 </FusionContent>
@@ -62,7 +62,7 @@ const NullableAndPlaceHolderContextSelectorStory = () => {
     return (
         <React.Fragment>
             <CurrentContextNullableAndPlaceholder>
-                <FusionHeader start={null} content={<ContextSelector />} aside={null} />
+                <FusionHeader start={null} content={ContextSelector} aside={null} />
                 <FusionContent>
                     <h1 style={{ textAlign: 'center', margin: 16 }}>PDP</h1>
                 </FusionContent>

--- a/src/components/core/Header/index.tsx
+++ b/src/components/core/Header/index.tsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 import ComponentDisplayToggleButton from './components/ComponentDisplayToggleButton';
 import CurrentUserButton from './components/CurrentUserButton';
 import { useHorizontalBreakpoint } from '@equinor/fusion-components';
+import AppManifest from '@equinor/fusion/lib/app/AppManifest';
 
 enum Breakpoints {
     medium = 'medium',
@@ -30,9 +31,13 @@ const breakpoints = [
     },
 ];
 
+type HeaderContentProps = {
+    app: AppManifest | null;
+};
+
 type FusionHeaderProps = {
     start: React.ReactElement | null;
-    content: React.ReactElement | null;
+    content: React.FC<HeaderContentProps> | null;
     aside: React.ReactElement | null;
 };
 
@@ -79,7 +84,7 @@ const FusionHeader: React.FC<FusionHeaderProps> = ({ start, content, aside }) =>
                 className={styles.contentContainer}
                 ref={headerContent as React.MutableRefObject<HTMLDivElement | null>}
             >
-                {content}
+                {content && React.createElement(content, { app: currentApp })}
             </div>
 
             <aside className={styles.asideContainer}>


### PR DESCRIPTION
Pass header content as a functional component instead of a rendered component.
Temporary workaround to solve [BUG 9880](https://dev.azure.com/statoil-proview/Fusion/_workitems/edit/9880).