### PR TITLE
Negative counts in filterPane

### DIFF
--- a/src/components/general/FilterPane/countFilters.ts
+++ b/src/components/general/FilterPane/countFilters.ts
@@ -55,7 +55,7 @@ const countFilter = async <T>(
     return -1;
 };
 
-const countFilters = async <T>(data: T[], { sectionDefinitions, terms }: FilterOptions<T>) => {
+const countFilters = async <T>(data: T[] = [], { sectionDefinitions, terms }: FilterOptions<T>) => {
     // Flatten section definitions to a list of filters
     const allFilters = sectionDefinitions.reduce(
         (filters, section) => filters.concat(section.filters),
@@ -82,10 +82,6 @@ const countFilters = async <T>(data: T[], { sectionDefinitions, terms }: FilterO
 
 const countFiltersAsync = <T>(data: T[], options: FilterOptions<T>) =>
     new Promise<Count[]>(resolve => {
-        if (!data || !data.length) {
-            return resolve([]);
-        }
-
         window.requestAnimationFrame(async () => {
             const result = await countFilters(data, options);
             resolve(result);


### PR DESCRIPTION

When FilterPane data is given empty or null values. Counts would end up with negative values. 
Instead of the filters not showing at all, since they should be empty.

This happens because countFiltersAsync jsut returns an empty array when data is empty or a null value. Instead of a object with the filters specified in the sectionDefinitions.
 
Fix removes the length check for data in the countFiltersAsync. 
countFilters has now an empty array as default value, if its empty. 
This ensures that the filtersCount object with filters specified in the sectionsDefintions gets built properly. 



