### PR TITLE
Added if initialPerson is set to null, then clear section

### DIFF
--- a/src/components/people/PersonPicker/index.tsx
+++ b/src/components/people/PersonPicker/index.tsx
@@ -20,7 +20,7 @@ export type PersonPickerOption = {
 type PersonPickerProps = {
     label?: string;
     placeholder?: string;
-    initialPerson?: PersonDetails;
+    initialPerson?: PersonDetails | null;
     selectedPerson: PersonDetails | null;
     hasError?: boolean;
     errorMessage?: string;
@@ -79,6 +79,9 @@ export default ({
     useEffect(() => {
         if (initialPerson && !isInitialized) {
             setSections(singlePersonToDropdownSection(initialPerson));
+        }
+        else {
+            setSections([]);
         }
     }, [isInitialized, initialPerson]);
 


### PR DESCRIPTION
If the prop `initialPerson` in PersonPicker is set, it is not possible to clear it out.
This is a fix for it.