### PR TITLE
Force reset filters on context change

### DIFF
--- a/src/components/data/PowerBIReport/index.tsx
+++ b/src/components/data/PowerBIReport/index.tsx
@@ -109,6 +109,11 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters }) => {
         }
     };
 
+    React.useEffect(() => {
+        if (!embeddedRef.current) return;
+        embeddedRef.current.reload();
+    }, [filters, embeddedRef]);
+
     const setFilter = async () => {
         if (!embedRef.current) return;
 


### PR DESCRIPTION
When changing context, selected filter in the report embed (right side filter) are not reset. 
So user might end up with filters that are no longer valid/selectable. 
the new useEffect will reload the report when the context filter get sendt in.

Was not able to find a solution where I was able to reset the filters without reloading. 


