### PR TITLE
Markdown viewer - Update sanitizer

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -16,7 +16,7 @@ addParameters({
 const req = require.context('../src', true, /\.stories\.(jsx|tsx)$/);
 
 const loadStories = () => {
-    req.keys().forEach(filename => req(filename));
+    req.keys().forEach((filename) => req(filename));
 };
 
 configure(loadStories, module);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -16,7 +16,7 @@ addParameters({
 const req = require.context('../src', true, /\.stories\.(jsx|tsx)$/);
 
 const loadStories = () => {
-    req.keys().forEach((filename) => req(filename));
+    req.keys().forEach(filename => req(filename));
 };
 
 configure(loadStories, module);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14870,6 +14870,12 @@
                 "domelementtype": "1"
             }
         },
+        "dompurify": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.8.tgz",
+            "integrity": "sha512-vIOSyOXkMx81ghEalh4MLBtDHMx1bhKlaqHDMqM2yeitJ996SLOk5mGdDpI9ifJAgokred8Rmu219fX4OltqXw==",
+            "dev": true
+        },
         "domutils": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
@@ -17198,8 +17204,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -17220,14 +17225,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -17242,20 +17245,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -17372,8 +17372,7 @@
                 "inherits": {
                     "version": "2.0.4",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -17385,7 +17384,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -17400,7 +17398,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -17408,14 +17405,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.9.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -17434,7 +17429,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -17524,8 +17518,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -17537,7 +17530,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -17623,8 +17615,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -17660,7 +17651,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -17680,7 +17670,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -17724,14 +17713,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17204,7 +17204,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -17225,12 +17226,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -17245,17 +17248,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -17372,7 +17378,8 @@
                 "inherits": {
                     "version": "2.0.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -17384,6 +17391,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -17398,6 +17406,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -17405,12 +17414,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.9.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -17429,6 +17440,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -17518,7 +17530,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -17530,6 +17543,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -17615,7 +17629,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -17651,6 +17666,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -17670,6 +17686,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -17713,12 +17730,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "cache-loader": "^4.1.0",
         "classnames": "^2.2.6",
         "css-loader": "^3.4.2",
+        "dompurify": "^2.0.8",
         "enzyme": "^3.9.0",
         "enzyme-adapter-react-16": "^1.12.1",
         "eslint": "5.16.0",

--- a/src/components/general/MarkdownViewer/index.tsx
+++ b/src/components/general/MarkdownViewer/index.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import marked from 'marked';
 import styles from './styles.less';
+import  dompurify from "dompurify";
 
 type MarkdownViewerProps = {
     markdown: string;
 };
 
 const MarkdownViewer: React.FC<MarkdownViewerProps> = ({ markdown }) => {
+
     return (
         <div className={styles.container} dangerouslySetInnerHTML={{ __html: marked(markdown) }} />
     );

--- a/src/components/general/MarkdownViewer/index.tsx
+++ b/src/components/general/MarkdownViewer/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import marked from 'marked';
 import styles from './styles.less';
-import  dompurify from "dompurify";
+import dompurify from 'dompurify';
 
 type MarkdownViewerProps = {
     markdown: string;
@@ -9,7 +9,10 @@ type MarkdownViewerProps = {
 
 const MarkdownViewer: React.FC<MarkdownViewerProps> = ({ markdown }) => {
     return (
-        <div className={styles.container} dangerouslySetInnerHTML={{ __html: dompurify(markdown) }} />
+        <div
+            className={styles.container}
+            dangerouslySetInnerHTML={{ __html: dompurify.sanitize(marked(markdown)) }}
+        />
     );
 };
 

--- a/src/components/general/MarkdownViewer/index.tsx
+++ b/src/components/general/MarkdownViewer/index.tsx
@@ -8,9 +8,8 @@ type MarkdownViewerProps = {
 };
 
 const MarkdownViewer: React.FC<MarkdownViewerProps> = ({ markdown }) => {
-
     return (
-        <div className={styles.container} dangerouslySetInnerHTML={{ __html: marked(markdown) }} />
+        <div className={styles.container} dangerouslySetInnerHTML={{ __html: dompurify(markdown) }} />
     );
 };
 

--- a/src/components/general/MarkdownViewer/index.tsx
+++ b/src/components/general/MarkdownViewer/index.tsx
@@ -7,20 +7,6 @@ type MarkdownViewerProps = {
 };
 
 const MarkdownViewer: React.FC<MarkdownViewerProps> = ({ markdown }) => {
-    const sanitizer = () => {
-        // This function callback receives non-markdown tokens for
-        // examination. For instance, for the input "<html>some text</html>",
-        // this function will be called twice with "<html>" and "</html>" as tokens respectively.
-
-        // For now, we will handle all non-markdown tokens equally and simply strip them away.
-        return '';
-    };
-
-    marked.setOptions({
-        sanitize: true,
-        sanitizer,
-    });
-
     return (
         <div className={styles.container} dangerouslySetInnerHTML={{ __html: marked(markdown) }} />
     );


### PR DESCRIPTION
It was deprecated and the sanitizer function removed the support for html in markdown

EDIT: Added dompurify to sanitize markdown input