### PR TITLE
 Expanding table shows too much white space

### DIFF
--- a/src/components/data/DataTable/components/Row.tsx
+++ b/src/components/data/DataTable/components/Row.tsx
@@ -49,9 +49,9 @@ function DataTableRow<T>({
                 isHovering={isHovering}
                 onMouseOver={setIsHoveringTrue}
                 onMouseOut={setIsHoveringFalse}
-                className={classNames(styles.cell)}
+                className={classNames(styles.cell, { [styles.isExpanded]: isExpanded })}
             />
-            {columns.map(column => (
+            {columns.map((column) => (
                 <Cell
                     key={column.key}
                     column={column}

--- a/src/components/data/DataTable/utils.ts
+++ b/src/components/data/DataTable/utils.ts
@@ -50,7 +50,7 @@ const toCssUnit = (value: number | string) => {
 
 export const generateColumnTemplate = <T>(columns: DataTableColumn<T>[]) =>
     'max-content max-content ' +
-    columns.map(c => toCssUnit(`minmax(max-content, ${c.width || 'auto'})`)).join(' ');
+    columns.map((c) => toCssUnit(`minmax(max-content, ${c.width || 'auto'})`)).join(' ');
 
 const rowTemplate = 'calc(var(--grid-unit) * var(--row-height-multiplier))';
 export const generateRowTemplate = <T>(rows: T[], expandedRows: T[], skeletonRows: number) => {
@@ -63,14 +63,14 @@ export const generateRowTemplate = <T>(rows: T[], expandedRows: T[], skeletonRow
         rowTemplate +
         ' ' +
         rows
-            .map(row => {
-                const isExpanded = expandedRows.findIndex(r => r === row) > -1;
+            .map((row) => {
+                const isExpanded = expandedRows.findIndex((r) => r === row) > -1;
 
                 if (!isExpanded) {
                     return rowTemplate;
                 }
 
-                return `${rowTemplate} auto`;
+                return `${rowTemplate} min-content`;
             })
             .join(' ')
     );
@@ -87,7 +87,7 @@ const getNextColumnToCollapse = <T>(
     // Remove already collapsed columns
     // Sort the columns by priority
     const sortedColumns = columns
-        .filter(c => !collapsedColumns.find(cc => cc.key === c.key))
+        .filter((c) => !collapsedColumns.find((cc) => cc.key === c.key))
         .sort((a, b) => {
             if (!a.priority) {
                 return -1;
@@ -196,9 +196,9 @@ export const useVisibleColumns = <T>(
 
     // Remove the collapsed columns, or the columns we're testing from all the columns before returning
     const visibleColumns = columns.filter(
-        c =>
+        (c) =>
             !(testCollapsedColumns.length ? testCollapsedColumns : collapsedColumns).find(
-                cc => cc.key === c.key
+                (cc) => cc.key === c.key
             )
     );
 


### PR DESCRIPTION
Expanded rows was set to auto, taking up as much spaceas it could. 
Changed this to min-content. Making it grow according to expandedContent.

while fixing the white space bug i noticed selection cell bottom-border was not removed when row was expanded. While it was removed on the other columns in that row. 
Added an IsExpanded check on the selection cell when creating rows. 
So the class also get toggled in the same way as the rest. 