### PR TITLE
Add scrollTo polyfill

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// Polyfills
+import './polyfills';
+
 // Core components
 export { default as FusionHeader, HeaderContentProps } from './components/core/Header';
 export { default as HeaderContentPortal } from './components/core/Header/HeaderContentPortal';

--- a/src/polyfills/index.ts
+++ b/src/polyfills/index.ts
@@ -1,0 +1,1 @@
+import './scrollTo';

--- a/src/polyfills/scrollTo.ts
+++ b/src/polyfills/scrollTo.ts
@@ -1,0 +1,23 @@
+if ('scrollTo' in Element.prototype === false) {
+    Element.prototype.scrollTo = function (options?: number | ScrollToOptions, y?: number) {
+        if (!options) {
+            return;
+        }
+
+        const scrollToOptions: ScrollToOptions = {
+            left:
+                typeof options === 'number'
+                    ? (options as number)
+                    : (options as ScrollToOptions).left,
+            top: y,
+        };
+
+        if (scrollToOptions.left) {
+            this.scrollLeft = scrollToOptions.left;
+        }
+
+        if (scrollToOptions.top) {
+            this.scrollTop = scrollToOptions.top;
+        }
+    };
+}


### PR DESCRIPTION
Edge (pre chromium) does not support Element.prototype.scrollTo as used by the stepper and tabs components. Implemented a polyfill which implements a custom version for browsers that does not support scrollTo.