### PR TITLE
Data Table no collapsing columns.

### DIFF
--- a/src/components/data/DataTable/__stories__/DataTable.stories.tsx
+++ b/src/components/data/DataTable/__stories__/DataTable.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import withFusionStory from '../../../../../.storybook/withFusionStory';
 import DataTable from '../index';
 import data, { fakeFetchAsync, DataItem } from './storyData';
-import columns, { simpleColumns, DataItemProps } from './columns';
+import columns, { simpleColumns, DataItemProps, wordWrapColumns } from './columns';
 import {
     Page,
     usePagination,
@@ -40,7 +40,7 @@ const WithSkeleton: React.FC = () => {
         [sortBy, direction]
     );
 
-    const sortedByColumn = columns.find(c => c.accessor === sortBy) || null;
+    const sortedByColumn = columns.find((c) => c.accessor === sortBy) || null;
 
     return (
         <DataTable
@@ -95,7 +95,7 @@ const WithoutSkeleton: React.FC = () => {
         [sortBy, direction]
     );
 
-    const sortedByColumn = columns.find(c => c.accessor === sortBy) || null;
+    const sortedByColumn = columns.find((c) => c.accessor === sortBy) || null;
 
     return (
         <DataTable
@@ -112,6 +112,48 @@ const WithoutSkeleton: React.FC = () => {
             }}
             expandedComponent={ExpandedItem}
             listComponent={ExpandedItem}
+        />
+    );
+};
+
+const NoColumnsCollapse: React.FC = () => {
+    const [appSettings, setAppSetting] = useAppSettings();
+    const perPage = parseInt(appSettings['perPage'], 10) || 20;
+
+    const { sortedData, setSortBy, sortBy, direction } = useSorting(data, null, null);
+    const { pagination, pagedData, setCurrentPage } = usePagination(
+        sortedData as DataItem[],
+        perPage
+    );
+
+    const onPaginationChange = useCallback((newPage: Page, perPage: number) => {
+        setCurrentPage(newPage.index, perPage);
+        setAppSetting('perPage', perPage);
+    }, []);
+
+    const onSortChange = useCallback(
+        (column: DataTableColumn<DataItem>) => {
+            setSortBy(column.accessor, null);
+        },
+        [sortBy, direction]
+    );
+
+    const sortedByColumn = columns.find((c) => c.accessor === sortBy) || null;
+
+    return (
+        <DataTable
+            noColumnsCollapse
+            columns={wordWrapColumns}
+            data={pagedData}
+            pagination={pagination}
+            onPaginationChange={onPaginationChange}
+            isFetching={false}
+            rowIdentifier={'id'}
+            onSortChange={onSortChange}
+            sortedBy={{
+                column: sortedByColumn,
+                direction,
+            }}
         />
     );
 };
@@ -139,7 +181,7 @@ const Selectable: React.FC = () => {
         [sortBy, direction]
     );
 
-    const sortedByColumn = columns.find(c => c.accessor === sortBy) || null;
+    const sortedByColumn = columns.find((c) => c.accessor === sortBy) || null;
 
     return (
         <DataTable
@@ -186,11 +228,11 @@ const SingleSelectable: React.FC = () => {
         [sortBy, direction]
     );
 
-    const sortedByColumn = simpleColumns.find(c => c.accessor === sortBy) || null;
+    const sortedByColumn = simpleColumns.find((c) => c.accessor === sortBy) || null;
 
     const handleClick = React.useCallback(
-        item => {
-            if (selectedItems.findIndex(i => i.id === item.id) !== -1) {
+        (item) => {
+            if (selectedItems.findIndex((i) => i.id === item.id) !== -1) {
                 setSelectedItems([]);
             } else {
                 setSelectedItems([item]);
@@ -226,4 +268,5 @@ storiesOf('Data|Data Table', module)
     .add('Default', () => <WithoutSkeleton />)
     .add('With skeleton', () => <WithSkeleton />)
     .add('Single selectable', () => <SingleSelectable />)
-    .add('Multi selectable', () => <Selectable />);
+    .add('Multi selectable', () => <Selectable />)
+    .add('No Columns Collapse', () => <NoColumnsCollapse />);

--- a/src/components/data/DataTable/__stories__/columns.tsx
+++ b/src/components/data/DataTable/__stories__/columns.tsx
@@ -94,4 +94,49 @@ export const simpleColumns: DataTableColumn<DataItem>[] = [
     },
 ];
 
+export const wordWrapColumns: DataTableColumn<DataItem>[] = [
+    {
+        key: 'id',
+        accessor: 'id',
+        label: 'Id',
+        sortable: true,
+        width: styling.grid(5),
+    },
+    {
+        key: 'firstName',
+        accessor: 'firstName',
+        label: 'First name',
+        sortable: true,
+    },
+    {
+        key: 'lastName',
+        accessor: 'lastName',
+        label: 'Last name',
+        sortable: true,
+    },
+    {
+        key: 'email',
+        accessor: 'email',
+        label: 'Email',
+        priority: 4,
+        sortable: true,
+        width: styling.grid(5),
+        component: ({ item }) => (
+            <div style={{ width: '190px', wordWrap: 'break-word' }}>{item.email}</div>
+        ),
+    },
+    {
+        key: 'delete',
+        accessor: 'id',
+        label: '',
+        component: DeleteColumn,
+        skeleton: DeleteColumnSkeleton,
+        width: styling.grid(17),
+        style: {
+            justifyContent: 'flex-end',
+        },
+        priority: 3,
+    },
+];
+
 export default columns;

--- a/src/components/data/DataTable/components/Table.tsx
+++ b/src/components/data/DataTable/components/Table.tsx
@@ -24,11 +24,15 @@ function Table<T>({
     isExpandable,
     expandedComponent,
     onRowClick,
+    noColumnsCollapse: noColumnsCollapse,
 }: DataTableTableProps<T>) {
     const tableRef = useRef<HTMLDivElement>(null);
     const skeletonRows = pagination ? pagination.perPage : 10;
 
-    const { visibleColumns, collapsedColumns } = useVisibleColumns(columns, tableRef, [data]);
+    const { visibleColumns, collapsedColumns } = noColumnsCollapse
+        ? { visibleColumns: columns, collapsedColumns: [] }
+        : useVisibleColumns(columns, tableRef, [data]);
+
     const columnTemplate = generateColumnTemplate(visibleColumns);
     const [expandedItems, setExpandedItems] = useState<T[]>([]);
     const rowTemplate = generateRowTemplate(data, expandedItems, skeletonRows);
@@ -48,12 +52,12 @@ function Table<T>({
 
     const handleOnExpand = useCallback(
         (item: T) => {
-            const existing = expandedItems.find(i => i === item);
+            const existing = expandedItems.find((i) => i === item);
 
             if (existing) {
-                setExpandedItems(expandedItems => expandedItems.filter(i => i !== existing));
+                setExpandedItems((expandedItems) => expandedItems.filter((i) => i !== existing));
             } else {
-                setExpandedItems(expandedItems => [...expandedItems, item]);
+                setExpandedItems((expandedItems) => [...expandedItems, item]);
             }
         },
         [expandedItems]

--- a/src/components/data/DataTable/dataTableTypes.ts
+++ b/src/components/data/DataTable/dataTableTypes.ts
@@ -55,9 +55,9 @@ export type DataTableProps<T> = {
     expandedComponent?: React.FC<DataItemComponentProps<T>>;
     onRowClick?: OnDataTableRowClickHandler<T>;
     onExpand?: (item: T) => void;
-
     listComponent?: React.FC<DataItemComponentProps<T>>;
     listSkeleton?: React.FC;
+    noColumnsCollapse?: boolean;
 };
 
 export type DataTableTableProps<T> = {
@@ -76,6 +76,7 @@ export type DataTableTableProps<T> = {
     expandedComponent?: React.FC<DataItemComponentProps<T>>;
     onRowClick?: OnDataTableRowClickHandler<T>;
     onExpand?: (item: T) => void;
+    noColumnsCollapse?: boolean;
 };
 
 export type DataTableListProps<T> = {

--- a/src/components/data/DataTable/index.tsx
+++ b/src/components/data/DataTable/index.tsx
@@ -41,6 +41,7 @@ function DataTable<T>({
     listComponent,
     listSkeleton,
     onRowClick,
+    noColumnsCollapse,
 }: DataTableProps<T>) {
     const showSkeleton = isFetching && !data.length;
 
@@ -86,6 +87,7 @@ function DataTable<T>({
                     onSelectionChange={onSelectionChange}
                     selectedItems={selectedItems}
                     onRowClick={onRowClick}
+                    noColumnsCollapse={noColumnsCollapse}
                 />
             )}
         </div>

--- a/src/components/data/DataTable/utils.ts
+++ b/src/components/data/DataTable/utils.ts
@@ -67,7 +67,7 @@ export const generateRowTemplate = <T>(rows: T[], expandedRows: T[], skeletonRow
                 const isExpanded = expandedRows.findIndex((r) => r === row) > -1;
 
                 if (!isExpanded) {
-                    return rowTemplate;
+                    return `minmax(${rowTemplate},auto)`;
                 }
 
                 return `${rowTemplate} min-content`;


### PR DESCRIPTION
Added a flag to datatable preventing columns to be collapsed
if the table is to wide for the view.
Instead it will just extend outside of the view, with a scrollbar.

size can be controlled by using limiting size off cells in the rows,
or making a custom component for the cell for more granular control.

one caveat here, just setting size on the cell will make it grow to fit. 
That is current behaviour. 
One could make it so the cells do not grow with its content, if its limited.. 
maybe forcing word-wrap/break if the content is to long. 
That would potentially be a breaking change. 


