### PR TITLE
Data Table columns expanded to fill full height

### DIFF
--- a/src/components/data/DataTable/utils.ts
+++ b/src/components/data/DataTable/utils.ts
@@ -67,7 +67,7 @@ export const generateRowTemplate = <T>(rows: T[], expandedRows: T[], skeletonRow
                 const isExpanded = expandedRows.findIndex((r) => r === row) > -1;
 
                 if (!isExpanded) {
-                    return `minmax(${rowTemplate},auto)`;
+                    return `minmax(${rowTemplate},min-content)`;
                 }
 
                 return `${rowTemplate} min-content`;


### PR DESCRIPTION
changed the max off minmax for nonExpanded columns to be min-content  instead of auto. Auto caused the grid to expand columns to fill the height of the space, when you had a smaller amount of columns.