### PR TITLE
Bug 9086: Fusion table component acts funny when long texts are content

### DIFF
--- a/src/components/data/DataTable/components/ExpandedContent.tsx
+++ b/src/components/data/DataTable/components/ExpandedContent.tsx
@@ -17,15 +17,23 @@ function DataTableExpandedContent<T>({
     const renderExpandedContent = () => {
         const ExpandedComponent = expandedComponent;
         if (ExpandedComponent) {
-            return <ExpandedComponent item={item} rowIndex={rowIndex} collapsedColumns={collapsedColumns}/>;
+            return (
+                <ExpandedComponent
+                    item={item}
+                    rowIndex={rowIndex}
+                    collapsedColumns={collapsedColumns}
+                />
+            );
         }
 
         return (
             <table>
                 <tbody>
-                    {collapsedColumns.map(column => (
+                    {collapsedColumns.map((column) => (
                         <tr key={column.key}>
-                            <td><strong>{column.label}</strong></td>
+                            <td className={styles.expandedLabel}>
+                                <strong>{column.label}</strong>
+                            </td>
                             <td>{getCellContent(item, column, rowIndex)}</td>
                         </tr>
                     ))}

--- a/src/components/data/DataTable/styles.less
+++ b/src/components/data/DataTable/styles.less
@@ -68,16 +68,22 @@
             }
         }
 
-        .expandedContent {
+        .expandedContent {            
             grid-column-start: 1;
             grid-column-end: -1;
+            max-width: fit-content;
             padding: calc(var(--grid-unit) * var(--expanded-content-padding-multiplier));
             border-bottom: 1px solid var(--border-color);
 
             td {
                 height: calc(var(--grid-unit) * var(--expanded-content-row-height-multiplier));
             }
+        
+            .expandedLabel {
+             white-space: nowrap;
+            }
         }
+
     }
 
     .pagination {

--- a/src/components/data/DataTable/utils.ts
+++ b/src/components/data/DataTable/utils.ts
@@ -49,7 +49,7 @@ const toCssUnit = (value: number | string) => {
 };
 
 export const generateColumnTemplate = <T>(columns: DataTableColumn<T>[]) =>
-    'max-content max-content ' +
+    'min-content min-content ' +
     columns.map((c) => toCssUnit(`minmax(max-content, ${c.width || 'auto'})`)).join(' ');
 
 const rowTemplate = 'calc(var(--grid-unit) * var(--row-height-multiplier))';


### PR DESCRIPTION
Fix to expandedContent by adding a max width.
Should now not expand the size of the table when opened.
Added a no wrap to expanded content label. so that it remains in one line if the row needs to wrap.
In util genrateColumnTemplte was changed for the selection and expanded content cells, making them min-content instead of max-content.
This because they were taking up space when opening up expanded content was opened, even if they were empty or didnt need more space.
causing the actually columns to be pushed further down.