### PR TITLE
Filter Pane - custom component in header 

### DIFF
--- a/src/components/general/FilterPane/__stories__/FilterPane.stories.tsx
+++ b/src/components/general/FilterPane/__stories__/FilterPane.stories.tsx
@@ -5,7 +5,7 @@ import FilterPane, { FilterTypes, FilterSection, FilterTerm } from '../index';
 import storyData, { DataItem } from './storyData';
 import columns from './columns';
 import { useAppSettings, useSorting, usePagination, Page } from '@equinor/fusion';
-import { styling, DataTable, DataTableColumn } from '@equinor/fusion-components';
+import { styling, DataTable, DataTableColumn, Button } from '@equinor/fusion-components';
 
 type TableProps = {
     data: DataItem[];
@@ -32,7 +32,7 @@ const Table: React.FC<TableProps> = ({ data }) => {
         [sortBy, direction]
     );
 
-    const sortedByColumn = columns.find(c => c.accessor === sortBy) || null;
+    const sortedByColumn = columns.find((c) => c.accessor === sortBy) || null;
 
     return (
         <DataTable
@@ -60,7 +60,7 @@ const sections: FilterSection<DataItem>[] = [
                 key: 'search',
                 title: '',
                 type: FilterTypes.Search,
-                getValue: item => item.firstName + item.lastName + item.email,
+                getValue: (item) => item.firstName + item.lastName + item.email,
             },
         ],
     },
@@ -74,7 +74,7 @@ const sections: FilterSection<DataItem>[] = [
                 title: '',
                 type: FilterTypes.Radio,
                 isVisibleWhenPaneIsCollapsed: true,
-                getValue: item => '',
+                getValue: (item) => '',
                 options: [
                     {
                         key: 'papayawhip',
@@ -103,7 +103,7 @@ const sections: FilterSection<DataItem>[] = [
                 key: 'gender',
                 title: 'Gender',
                 type: FilterTypes.Checkbox,
-                getValue: item => item.gender,
+                getValue: (item) => item.gender,
                 isVisibleWhenPaneIsCollapsed: true,
                 isCollapsible: true,
                 options: [
@@ -122,7 +122,7 @@ const sections: FilterSection<DataItem>[] = [
                 key: 'id',
                 title: 'Id - with custom colors',
                 type: FilterTypes.Checkbox,
-                getValue: item => item.id.toString(),
+                getValue: (item) => item.id.toString(),
                 isCollapsible: true,
                 isCollapsed: false,
                 options: [
@@ -155,24 +155,46 @@ const FilterPaneStory: React.FC = () => {
         },
     ]);
     const [filteredData, setFilteredData] = useState<DataItem[]>(storyData);
+    const [filterScreenPlacement, setFilterScreenPlacement] = useState('right');
 
     const onChange = (filteredData: DataItem[], newTerms: FilterTerm[]) => {
         setTerms(newTerms);
         setFilteredData(filteredData);
     };
 
+    const changeSide = () => {
+        setFilterScreenPlacement(filterScreenPlacement === 'right' ? 'left' : 'right');
+    };
+
+    const filterHeaderComponent = (
+        <div style={{ marginRight: '8px' }}>
+            <Button frameless onClick={changeSide}>
+                Flip pane {filterScreenPlacement === 'right' ? 'left' : 'right'}
+            </Button>
+        </div>
+    );
+
     return (
         <div style={{ display: 'flex', height: '100%', width: '100%' }}>
-            <div style={{ marginRight: styling.grid(4), width: 1, flexGrow: 1 }}>
-                <Table data={filteredData} />
-            </div>
+            {filterScreenPlacement === 'right' && (
+                <div style={{ marginRight: styling.grid(4), width: 1, flexGrow: 1 }}>
+                    <Table data={filteredData} />
+                </div>
+            )}
             <FilterPane
                 id="story"
                 data={storyData}
                 sectionDefinitions={sections}
                 terms={terms}
                 onChange={onChange}
+                screenPlacement={filterScreenPlacement}
+                headerComponent={filterHeaderComponent}
             />
+            {filterScreenPlacement === 'left' && (
+                <div style={{ marginRight: styling.grid(4), width: 1, flexGrow: 1 }}>
+                    <Table data={filteredData} />
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/general/FilterPane/index.tsx
+++ b/src/components/general/FilterPane/index.tsx
@@ -37,6 +37,7 @@ export type FilterPaneProps<T> = {
     onChange: OnFilterChangeHandler<T>;
     screenPlacement?: 'right' | 'left';
     onToggleCollapse?: (isCollapsed: boolean) => void;
+    headerComponent?: React.ReactNode;
 };
 
 function FilterPane<T>({
@@ -47,6 +48,7 @@ function FilterPane<T>({
     onChange,
     screenPlacement = 'right',
     onToggleCollapse,
+    headerComponent,
 }: FilterPaneProps<T>) {
     const [isCollapsed, setIsCollapsed] = useState(getDefaultCollapsed(id));
     const [filterCount, setFilterCount] = useState<Count[]>([]);
@@ -106,9 +108,10 @@ function FilterPane<T>({
                     <div className={styles.collapseExpandButtonContainer}>
                         <CollapseExpandButton onClick={toggleCollapsed} />
                     </div>
+                    {!isCollapsed && headerComponent}
                 </div>
                 <div className={styles.content}>
-                    {sectionDefinitions.map(section => (
+                    {sectionDefinitions.map((section) => (
                         <Section
                             key={section.key}
                             section={section}
@@ -123,7 +126,7 @@ function FilterPane<T>({
     );
 }
 
-export default props => (
+export default (props) => (
     <ErrorBoundary>
         <FilterPane {...props} />
     </ErrorBoundary>

--- a/src/components/general/FilterPane/styles.less
+++ b/src/components/general/FilterPane/styles.less
@@ -23,12 +23,17 @@
         overflow: hidden;
         flex-shrink: 0;
         padding: 0;
+        position: sticky;
+        top:0;
+        background-color: var(--color-white);
+        border-bottom: 1px solid var(--color-black-alt4);
+        z-index: 10;
+        justify-content: space-between;
     }
 
     .collapseExpandButtonContainer {
         width: calc(var(--grid-unit) * 6px);
         height: calc(var(--grid-unit) * 6px);
-        border-bottom: 1px solid var(--color-black-alt4);
         display: flex;
         justify-content: center;
         align-items: center;


### PR DESCRIPTION
FilterPane header is now sticked to the top when scrolling.
FilterPane Header can now receive a component.
It will be aligned on the opposite side of the collapse-arrow.
Component will be hidden when collapsing filterpane.

Added a small filter header component to the Filter Pane story. Demoing how this works.
It just flips the filter pane placement back and forth from right to left.