### PR TITLE
Filter Pane - checkboxes get unaligned when text is long

### DIFF
--- a/src/components/general/FilterPane/components/CheckBoxesFilterComponent.tsx
+++ b/src/components/general/FilterPane/components/CheckBoxesFilterComponent.tsx
@@ -88,7 +88,9 @@ const CheckboxWrapper: React.FC<CheckBoxWrapperProps> = ({
 
     return (
         <li onClick={selectSingleOption} ref={tooltipRef}>
-            <CheckBox selected={isChecked} color={option.color} onChange={toggleOption} />
+            <span>
+                <CheckBox selected={isChecked} color={option.color} onChange={toggleOption} />
+            </span>
             {!filterPaneContext.paneIsCollapsed && (
                 <label>
                     {option.label}


### PR DESCRIPTION
If the label text for checkbox filters get long or breaks into multiple lines. 
The text would squish the width of the check box. 
How much widht the checkbox lost could be different between the filters. 
Cassing them to be unaliged by a couple of pixels and you end up with a fairly messy look. 

To fix this i wrapped checkbox in span tag.
This ensures that the checkbox keeps its size and ratio when the label text gets long or goes over multiple lines


