### PR TITLE
new optional overrideOnRowClick props for datatabelColumn. 

### DIFF
--- a/src/components/data/DataTable/components/Row.tsx
+++ b/src/components/data/DataTable/components/Row.tsx
@@ -62,7 +62,7 @@ function DataTableRow<T>({
                     isSelected={isSelected}
                     onMouseOver={setIsHoveringTrue}
                     onMouseOut={setIsHoveringFalse}
-                    onClick={onClick}
+                    onClick={column.overrideOnRowClick ? null : onClick}
                 />
             ))}
             <ExpandedContent

--- a/src/components/data/DataTable/dataTableTypes.ts
+++ b/src/components/data/DataTable/dataTableTypes.ts
@@ -24,6 +24,7 @@ export type DataTableColumn<T> = {
     skeleton?: React.FC<DataItemSkeletonComponentProps>;
     style?: React.CSSProperties;
     sortable?: DataItemBooleanAccessor<T>;
+    overrideOnRowClick?: boolean;
 
     /** High value or falsy value will be collapsed first when there's no space for all columns */
     priority?: number;


### PR DESCRIPTION
new optional overrideOnRowClick props for datatabelColumn. 
Will be checked when row.tsx is iterating the rows. 
If set to true universal onclick event set on the datatable will be removed from this one column. 

This enabled having an onClick event on the component, if you pass this in with the columns. 
How it stands now the onRowClick event will fire, regardless if the custom component has an onClick event or not. 
The components onclick event will not fire. 

The immidiate use case for this is in the new report admin update. 
The lines should be click able and open report directly. 
While at the same time, there is a new menu column, that needs to be clickable without triggering the onRowClick. 



