### PR TITLE
Make expandable rows 100% width

### DIFF
--- a/src/components/data/DataTable/__stories__/DataTable.stories.tsx
+++ b/src/components/data/DataTable/__stories__/DataTable.stories.tsx
@@ -267,6 +267,65 @@ const SingleSelectable: React.FC = () => {
     );
 };
 
+const ExpandableRows: React.FC = () => {
+    const [appSettings, setAppSetting] = useAppSettings();
+    const perPage = parseInt(appSettings['perPage'], 10) || 20;
+
+    const [selectedItems, setSelectedItems] = useState<DataItem[]>([]);
+    const { sortedData, setSortBy, sortBy, direction } = useSorting(data, null, null);
+    const { pagination, pagedData, setCurrentPage } = usePagination(
+        sortedData as DataItem[],
+        perPage
+    );
+
+    const onPaginationChange = useCallback((newPage: Page, perPage: number) => {
+        setCurrentPage(newPage.index, perPage);
+        setAppSetting('perPage', perPage);
+    }, []);
+
+    const onSortChange = useCallback(
+        (column: DataTableColumn<DataItem>) => {
+            setSortBy(column.accessor, null);
+        },
+        [sortBy, direction]
+    );
+
+    const sortedByColumn = simpleColumns.find((c) => c.accessor === sortBy) || null;
+
+    const handleClick = React.useCallback(
+        (item) => {
+            if (selectedItems.findIndex((i) => i.id === item.id) !== -1) {
+                setSelectedItems([]);
+            } else {
+                setSelectedItems([item]);
+            }
+        },
+        [selectedItems]
+    );
+
+    return (
+        <DataTable
+            columns={simpleColumns}
+            data={pagedData}
+            pagination={pagination}
+            onPaginationChange={onPaginationChange}
+            isFetching={false}
+            rowIdentifier={'id'}
+            onSortChange={onSortChange}
+            sortedBy={{
+                column: sortedByColumn,
+                direction,
+            }}
+            isExpandable={true}
+            expandedComponent={ExpandedItem}
+            listComponent={ExpandedItem}
+            onRowClick={handleClick}
+            selectedItems={selectedItems}
+            quickFactScope={"storybook"}
+        />
+    );
+};
+
 storiesOf('Data/Data Table', module)
     .addParameters({ jest: ['DataTable.stories.jsx'] })
     .addDecorator(withFusionStory('Data Table'))
@@ -274,4 +333,5 @@ storiesOf('Data/Data Table', module)
     .add('With skeleton', () => <WithSkeleton />)
     .add('Single selectable', () => <SingleSelectable />)
     .add('Multi selectable', () => <Selectable />)
-    .add('No Columns Collapse', () => <NoColumnsCollapse />);
+    .add('No Columns Collapse', () => <NoColumnsCollapse />)
+    .add('With expandable rows', () => <ExpandableRows />);

--- a/src/components/data/DataTable/styles.less
+++ b/src/components/data/DataTable/styles.less
@@ -73,7 +73,6 @@
         .expandedContent {            
             grid-column-start: 1;
             grid-column-end: -1;
-            max-width: fit-content;
             padding: calc(var(--grid-unit) * var(--expanded-content-padding-multiplier));
             border-bottom: 1px solid var(--border-color);
 


### PR DESCRIPTION
Expandable items had a fit-content property that makes expandable items shorter than the DataTable. Removed that property. Also added a story for table columns with expandable items that is always visible. 

**I don't know if this will impact something important in Fusion!**

**Before**
![Screenshot 2020-09-25 at 15 27 50](https://user-images.githubusercontent.com/5803429/94273015-2a414100-ff44-11ea-8406-635fd08a360c.png)

**After**
![image](https://user-images.githubusercontent.com/5803429/94272973-1a296180-ff44-11ea-9941-db45157509ae.png)

