### PR TITLE
feat: Report new context access and error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,9 +1422,9 @@
             "dev": true
         },
         "@equinor/fusion": {
-            "version": "2.4.5",
-            "resolved": "https://registry.npmjs.org/@equinor/fusion/-/fusion-2.4.5.tgz",
-            "integrity": "sha512-H1mOKVsjYmdS51gdn6WegIBy2ItxGOj4d4SXEMvtnv4N8FqD50gANbb26OTud6Ch8fb/v8qPVO6N+sOeMtcTLw==",
+            "version": "2.4.8",
+            "resolved": "https://registry.npmjs.org/@equinor/fusion/-/fusion-2.4.8.tgz",
+            "integrity": "sha512-vtpPvljJNLRze80m/Jmv7w532P7OA4VZzP/SNFxp7MamhcoanbMckfs+thcIDa346jmxtv6/s8JWCkOc5ieI6A==",
             "dev": true,
             "requires": {
                 "@microsoft/applicationinsights-web": "^2.4.3",
@@ -24771,7 +24771,6 @@
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -24790,7 +24789,6 @@
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -24823,7 +24821,6 @@
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -24836,7 +24833,6 @@
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -24891,8 +24887,7 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
                     "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "4.0.1",
@@ -24909,7 +24904,6 @@
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -24919,7 +24913,6 @@
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -24930,15 +24923,13 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -24972,7 +24963,6 @@
                     "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
                     "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "is-number": "^3.0.0",
                         "repeat-string": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
-    "@equinor/fusion": "^2.4.5",
+    "@equinor/fusion": "^2.4.8",
     "@storybook/addon-actions": "^6.0.21",
     "@storybook/addon-docs": "^6.0.21",
     "@storybook/addon-jest": "^6.0.21",

--- a/src/components/data/PowerBIReport/__stories__/Reports.stories.tsx
+++ b/src/components/data/PowerBIReport/__stories__/Reports.stories.tsx
@@ -16,22 +16,22 @@ const ReportStandard: React.FC = () => {
 const ReportWithFilter: React.FC = () => {
     const [filterStrings, setFilterStrings] = React.useState<string[]>(null);
 
-    const createFilter = (filters: string[]): IBasicFilter => {
-        return {
-            $schema: 'http://powerbi.com/product/schema#basic',
-            target: {
-                table: 'Dim_Commonlibrary_Projects',
-                column: 'Project',
-            },
-            filterType: 1,
-            operator: 'In',
-            values: filters,
-        };
-    };
-
-    const filter = React.useMemo(() => {
-        return filterStrings ? createFilter(filterStrings) : null;
-    }, [filterStrings]);
+    const filter: IBasicFilter = React.useMemo(
+        () =>
+            filterStrings
+                ? {
+                      $schema: 'http://powerbi.com/product/schema#basic',
+                      target: {
+                          table: 'Dim_Commonlibrary_Projects',
+                          column: 'Project',
+                      },
+                      filterType: 1,
+                      operator: 'In',
+                      values: filterStrings,
+                  }
+                : null,
+        [filterStrings]
+    );
 
     return (
         <>
@@ -77,7 +77,7 @@ const ReportWithFilter: React.FC = () => {
             <div style={{ width: '100%', height: '100%' }}>
                 <PowerBIReport
                     reportId={'2e90a309-625e-4396-9a5d-45e99f5b3493'}
-                    filters={filter ? [filter] : null}
+                    filters={[filter]}
                 />
             </div>
         </>

--- a/src/components/data/PowerBIReport/components/ReportErrorMessage/index.tsx
+++ b/src/components/data/PowerBIReport/components/ReportErrorMessage/index.tsx
@@ -14,9 +14,10 @@ import classNames from 'classnames';
 
 type ReportErrorMessageProps = {
     report: Report;
+    contextError: boolean;
 };
 
-const ReportErrorMessage: React.FC<ReportErrorMessageProps> = ({ report }) => {
+const ReportErrorMessage: React.FC<ReportErrorMessageProps> = ({ report, contextError }) => {
     const [isFetching, setIsFetching] = React.useState<boolean>(true);
     const [requirements, setRequirements] = React.useState<string | null>(null);
     const [description, setDescription] = React.useState<string | null>(null);
@@ -28,6 +29,14 @@ const ReportErrorMessage: React.FC<ReportErrorMessageProps> = ({ report }) => {
     const reportApiClient = useApiClients().report;
     const user = useCurrentUser();
     const timeStamp = React.useMemo(() => new Date().toString(), []);
+
+    const errorHeader = React.useMemo(
+        () =>
+            contextError
+                ? 'It looks like you do not have access to the selected context'
+                : 'It looks like you do not have access to this report',
+        [contextError]
+    );
 
     React.useEffect(() => {
         getReportInformation();
@@ -73,7 +82,7 @@ const ReportErrorMessage: React.FC<ReportErrorMessageProps> = ({ report }) => {
                         styles.restrictedAccessContainer
                     )}
                 >
-                    <h2>It looks like you do not have access to this report</h2>
+                    <h2>{errorHeader}</h2>
                     {noAccessMessage && <MarkdownViewer markdown={noAccessMessage} />}
                     <div className={styles.reportInfoContainer}>
                         {description && (

--- a/src/components/data/PowerBIReport/index.tsx
+++ b/src/components/data/PowerBIReport/index.tsx
@@ -152,6 +152,7 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters, hasContext }
 
     React.useEffect(() => {
         if (!embeddedRef.current) return;
+
         setIsLoading(true);
 
         embeddedRef.current.reload();
@@ -337,7 +338,10 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters, hasContext }
         }
     }, [embedRef, accessToken, isFetching]);
 
-    if (powerBIError || fusionError) {
+    if (
+        (powerBIError && powerBIError.detail.errorCode) ||
+        (fusionError && fusionError.fusionError?.error?.code)
+    ) {
         //Only handling selected errors from Power BI. As you migh get errors that can be ignored.
         const errorCode = powerBIError
             ? powerBIError?.detail?.errorCode


### PR DESCRIPTION
Added new access check for Context.
Check calls the new checkContextAccess endpoint.
If user does not have access to the choosen context, the ReportErrorMessage will show.
Update ReportErrorMessage to show different header depending on how they got denied access.
If its RLS issue or context issue.

Also added a case for notFound in error handling.
This can happen when the token endpoint did not find the report.