### PR TITLE
fix:Report Component : Context Access check bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,9 +1422,9 @@
             "dev": true
         },
         "@equinor/fusion": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@equinor/fusion/-/fusion-2.4.8.tgz",
-            "integrity": "sha512-vtpPvljJNLRze80m/Jmv7w532P7OA4VZzP/SNFxp7MamhcoanbMckfs+thcIDa346jmxtv6/s8JWCkOc5ieI6A==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@equinor/fusion/-/fusion-2.4.10.tgz",
+            "integrity": "sha512-vB/GRY/WiMSPKUemFUAE3K2ZhMGgbXQdBok4RUsWTpUar5IKvqSlpJdIdd5x8R8X/El59mKsYcFzTe9SF7hlaA==",
             "dev": true,
             "requires": {
                 "@microsoft/applicationinsights-web": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
-    "@equinor/fusion": "^2.4.8",
+    "@equinor/fusion": "^2.4.10",
     "@storybook/addon-actions": "^6.0.21",
     "@storybook/addon-docs": "^6.0.21",
     "@storybook/addon-jest": "^6.0.21",


### PR DESCRIPTION
Access error didnt properly distinguish between Context or Token error.
Meaning you would always get an error saying you dont have access to the context, irregardles if it was report or context at fault.
Also wrapped the checkContextAccess in a callback hook.