### PR TITLE
Power BI Report  - Reembed report fix 

### DIFF
--- a/src/components/data/PowerBIReport/components/ReportEmbed/index.tsx
+++ b/src/components/data/PowerBIReport/components/ReportEmbed/index.tsx
@@ -194,7 +194,7 @@ const ReportEmbed: React.FC<PowerBIProps> = ({
                 return () =>
                     embeddedRef?.current ? embeddedRef.current.off('pageChanged') : undefined;
         }
-    }, [filters, embeddedRef.current, embedInfo]);
+    }, [filters, embeddedRef.current, embedInfo, awaitableBookmark]);
 
     React.useEffect(() => {
         if (!isLoading) setFilter();

--- a/src/components/data/PowerBIReport/components/ReportEmbed/index.tsx
+++ b/src/components/data/PowerBIReport/components/ReportEmbed/index.tsx
@@ -1,0 +1,247 @@
+import * as React from 'react';
+import * as pbi from 'powerbi-client';
+import { IError } from 'powerbi-models';
+import { useTelemetryLogger, useCurrentApp, Context } from '@equinor/fusion';
+import { ICustomEvent } from 'service';
+import {
+    AccessToken,
+    ResourceType,
+    EmbedInfo,
+    EmbedConfig,
+} from '@equinor/fusion/lib/http/apiClients/models/report/';
+import { AppSettingsManager } from '@equinor/fusion-components';
+
+import * as styles from '../../styles.less';
+import { ButtonClickEvent } from '../../models/EventHandlerTypes';
+
+type PowerBIProps = {
+    reportId: string;
+    embedInfo: EmbedInfo;
+    accessToken: AccessToken;
+    setError: React.Dispatch<
+        React.SetStateAction<pbi.service.ICustomEvent<pbi.models.IError> | null>
+    >;
+    currentContext: Context | null;
+    filters?: pbi.models.ReportLevelFilters[] | null;
+    hasContext?: boolean;
+};
+
+const getReportOrDashboardId = (embedConfig: EmbedConfig, type: ResourceType) => {
+    switch (type) {
+        case 'Report':
+            return embedConfig.reportId;
+        case 'Dashboard':
+            return embedConfig.dashboardId;
+    }
+};
+
+const getTokenType = (embedConfig: EmbedConfig) => {
+    switch (embedConfig.tokenType) {
+        case 'AAD':
+            return pbi.models.TokenType.Aad;
+        case 'Embed':
+            return pbi.models.TokenType.Embed;
+    }
+};
+
+const powerbi = new pbi.service.Service(
+    pbi.factories.hpmFactory,
+    pbi.factories.wpmpFactory,
+    pbi.factories.routerFactory
+);
+
+/**
+ * TODO: use native react component from Microsoft
+ */
+const ReportEmbed: React.FC<PowerBIProps> = ({
+    reportId,
+    embedInfo,
+    accessToken,
+    setError,
+    currentContext,
+    filters,
+    hasContext,
+}) => {
+    const [isLoading, setIsLoading] = React.useState<boolean>(true);
+    const [timeLoadStart, SetTimeLoadStart] = React.useState<Date>(new Date());
+    const telemetryLogger = useTelemetryLogger();
+    const [reApplyFilter, setReapplyFilter] = React.useState<boolean>(false);
+    const embedRef = React.useRef<HTMLDivElement>(null);
+    const embeddedRef = React.useRef<pbi.Embed | null>(null);
+    const [awaitableBookmark, setAwaitableBookmark] = React.useState<string | null>(null);
+
+    const applyBookmark = async (bookmark: string, awaitForContextSwitch: boolean) => {
+        const currentReport =
+            embedRef && embedRef.current ? (powerbi.get(embedRef.current) as pbi.Report) : null;
+        if (awaitForContextSwitch) {
+            setAwaitableBookmark(bookmark);
+            return;
+        }
+        if (!currentReport) {
+            return;
+        }
+        return currentReport.bookmarksManager.applyState(bookmark);
+    };
+
+    const captureBookmark = async () => {
+        const currentReport =
+            embedRef && embedRef.current ? (powerbi.get(embedRef.current) as pbi.Report) : null;
+        if (!currentReport) {
+            return;
+        }
+        const bookmark = await currentReport.bookmarksManager.capture();
+        return bookmark.state;
+    };
+
+    const setFilter = async () => {
+        if (!embedRef.current) return;
+
+        const report = powerbi.get(embedRef.current) as pbi.Report;
+        if (!report) return;
+
+        filters ? await report.setFilters(filters) : await report.removeFilters();
+        if (awaitableBookmark) {
+            applyBookmark(awaitableBookmark, false);
+            setAwaitableBookmark(null);
+        }
+    };
+
+    const getConfig = React.useCallback(
+        (embedInfo: EmbedInfo) => {
+            const embedConfig = embedInfo.embedConfig;
+            const token = accessToken ? accessToken.token : undefined;
+            let config: pbi.IEmbedConfiguration = {
+                type: embedInfo.embedConfig.embedType.toLowerCase(),
+                id: getReportOrDashboardId(embedConfig, embedInfo.embedConfig.embedType),
+                embedUrl: embedConfig.embedUrl,
+                tokenType: getTokenType(embedConfig),
+                accessToken: token,
+            };
+
+            if (embedInfo.embedConfig.embedType === 'Report') {
+                const settings = {
+                    filterPaneEnabled: false,
+                    navContentPaneEnabled: false,
+                    localeSettings: {
+                        formatLocale: 'en',
+                        language: 'en',
+                    },
+                };
+
+                config.settings = settings;
+                config.permissions = pbi.models.Permissions.All;
+            } else {
+                config.pageView = 'fitToWidth';
+            }
+
+            return config;
+        },
+        [accessToken]
+    );
+
+    const embed = React.useCallback(
+        (node: HTMLDivElement) => {
+            if (embedInfo) {
+                const config = getConfig(embedInfo);
+
+                embeddedRef.current = powerbi.embed(node, config);
+                embeddedRef.current.off('loaded');
+                embeddedRef.current.off('error');
+                embeddedRef.current.off('rendered');
+                embeddedRef.current.off('buttonClicked');
+                embeddedRef.current.on('loaded', () => {
+                    telemetryLogger.trackMetric({
+                        name: `${useCurrentApp.name}-EmbedLoadedTime`,
+                        average: (new Date().getTime() - timeLoadStart.getTime()) / 1000,
+                        sampleCount: 1,
+                    });
+                });
+                embeddedRef.current.on('rendered', () => {
+                    telemetryLogger.trackMetric({
+                        name: `${useCurrentApp.name}-EmbedRenderedTime`,
+                        average: (new Date().getTime() - timeLoadStart.getTime()) / 1000,
+                        sampleCount: 1,
+                    });
+                });
+                embeddedRef.current.on('error', (err: ICustomEvent<IError>) => {
+                    if (err && err.detail) {
+                        telemetryLogger.trackException({
+                            error: new Error('Power BI: ' + err.detail.message),
+                        });
+                    }
+                    setError(err);
+                });
+                embeddedRef.current.on(
+                    'buttonClicked',
+                    (button: ICustomEvent<ButtonClickEvent>) => {
+                        if (button?.detail?.title?.toLowerCase() === 'reset filter') {
+                            setReapplyFilter(true);
+                        }
+                    }
+                );
+            }
+        },
+        [embedInfo, getConfig, reportId]
+    );
+
+    /** TODO: add filters for dashboard if needed? */
+    React.useLayoutEffect(() => {
+        const embedType = embedInfo?.embedConfig?.embedType;
+        if (!embeddedRef.current || !embedType) return;
+        switch (embedType) {
+            case 'Report':
+                embeddedRef.current.on('pageChanged', setFilter);
+                return () =>
+                    embeddedRef?.current ? embeddedRef.current.off('pageChanged') : undefined;
+        }
+    }, [filters, embeddedRef.current, embedInfo]);
+
+    React.useEffect(() => {
+        if (!isLoading) setFilter();
+    }, [isLoading]);
+
+    React.useEffect(() => {
+        if (!embeddedRef.current) return;
+
+        setIsLoading(true);
+        embeddedRef.current.reload();
+    }, [currentContext?.id]);
+
+    React.useEffect(() => {
+        if (!embeddedRef.current) return;
+
+        embeddedRef.current.off('rendered');
+        embeddedRef.current.on('rendered', () => {
+            if (reApplyFilter) setFilter();
+            setReapplyFilter(false);
+        });
+    }, [reApplyFilter]);
+
+    React.useEffect(() => {
+        if (!embedRef?.current || !accessToken) return;
+
+        embed(embedRef.current);
+    }, [embedRef?.current, accessToken]);
+
+    React.useEffect(() => {
+        if (!embedRef?.current) return;
+
+        const embededReport = powerbi.get(embedRef.current);
+        if (embededReport && accessToken) embededReport.setAccessToken(accessToken.token);
+    }, [embedRef?.current, accessToken]);
+
+    return (
+        <>
+            <div className={styles.powerbiContent} ref={embedRef}></div>
+            <AppSettingsManager
+                captureAppSetting={captureBookmark}
+                applyAppSetting={applyBookmark}
+                hasContext={hasContext}
+                anchorId="pbi-bookmarks-btn"
+                name="Power BI bookmarks"
+            />
+        </>
+    );
+};
+
+export default ReportEmbed;

--- a/src/components/data/PowerBIReport/index.tsx
+++ b/src/components/data/PowerBIReport/index.tsx
@@ -1,23 +1,16 @@
 import * as React from 'react';
 import * as pbi from 'powerbi-client';
 import { IError } from 'powerbi-models';
-import { Spinner, ErrorMessage, AppSettingsManager } from '@equinor/fusion-components';
+import { Spinner, ErrorMessage } from '@equinor/fusion-components';
 import {
-    useTelemetryLogger,
     FusionApiHttpErrorResponse,
-    useCurrentApp,
     useCurrentContext,
     useApiClients,
+    ContextTypes,
 } from '@equinor/fusion';
 import { ICustomEvent } from 'service';
 import FusionError from './models/FusionError';
-import {
-    Report,
-    AccessToken,
-    ResourceType,
-    EmbedInfo,
-    EmbedConfig,
-} from '@equinor/fusion/lib/http/apiClients/models/report/';
+import { Report, AccessToken, EmbedInfo } from '@equinor/fusion/lib/http/apiClients/models/report/';
 import {
     ReportLevelFilters,
     IBasicFilter,
@@ -27,40 +20,15 @@ import {
     ITupleFilter,
 } from './models/ReportLevelFilters';
 
-import * as styles from './styles.less';
-import { ButtonClickEvent } from './models/EventHandlerTypes';
-
 import ReportErrorMessage from './components/ReportErrorMessage';
+import ReportEmbed from './components/ReportEmbed';
 
 type PowerBIProps = {
     reportId: string;
     filters?: pbi.models.ReportLevelFilters[] | null;
     hasContext?: boolean;
+    contextAccessCheck?: boolean;
 };
-
-const getReportOrDashboardId = (embedConfig: EmbedConfig, type: ResourceType) => {
-    switch (type) {
-        case 'Report':
-            return embedConfig.reportId;
-        case 'Dashboard':
-            return embedConfig.dashboardId;
-    }
-};
-
-const getTokenType = (embedConfig: EmbedConfig) => {
-    switch (embedConfig.tokenType) {
-        case 'AAD':
-            return pbi.models.TokenType.Aad;
-        case 'Embed':
-            return pbi.models.TokenType.Embed;
-    }
-};
-
-const powerbi = new pbi.service.Service(
-    pbi.factories.hpmFactory,
-    pbi.factories.wpmpFactory,
-    pbi.factories.routerFactory
-);
 
 const utcNow = () => {
     const date = new Date();
@@ -83,25 +51,23 @@ let timeout: NodeJS.Timeout;
 /**
  * TODO: use native react component from Microsoft
  */
-const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters, hasContext }) => {
+const PowerBIReport: React.FC<PowerBIProps> = ({
+    reportId,
+    filters,
+    hasContext,
+    contextAccessCheck,
+}) => {
     const reportApiClient = useApiClients().report;
     const currentContext = useCurrentContext();
 
-    const [isLoading, setIsLoading] = React.useState<boolean>(true);
     const [isFetching, setIsFetching] = React.useState<boolean>(true);
-    const [powerBIError, setPowerBIError] = React.useState<ICustomEvent<IError>>();
-    const [fusionError, setFusionError] = React.useState<FusionError>();
-
+    const [powerBIError, setPowerBIError] = React.useState<ICustomEvent<IError> | null>(null);
+    const [fusionError, setFusionError] = React.useState<FusionError | null>(null);
+    const [contextError, setContextError] = React.useState<FusionError | null>(null);
     const [report, setReport] = React.useState<Report>();
     const [embedInfo, setEmbedInfo] = React.useState<EmbedInfo>();
     const [accessToken, setAccessToken] = React.useState<AccessToken>();
-    const [timeLoadStart, SetTimeLoadStart] = React.useState<Date>(new Date());
-    const telemetryLogger = useTelemetryLogger();
-    const [reApplyFilter, setReapplyFilter] = React.useState<boolean>(false);
     const [loadingText, setLoadingText] = React.useState<string>('Loading Report');
-    const embedRef = React.useRef<HTMLDivElement>(null);
-    const embeddedRef = React.useRef<pbi.Embed | null>(null);
-    const [awaitableBookmark, setAwaitableBookmark] = React.useState<string | null>(null);
 
     const getReportInfo = async () => {
         try {
@@ -124,184 +90,39 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters, hasContext }
                 fusionError: error.response as FusionApiHttpErrorResponse,
             });
             setIsFetching(false);
-            setIsLoading(false);
         }
     };
 
-    const checkContextAccess = React.useCallback(async () => {
-        if (!currentContext?.externalId || !embedInfo?.embedConfig.rlsConfiguration) return;
-        try {
-            await reportApiClient.checkContextAccess(
-                reportId,
-                currentContext.externalId,
-                currentContext.type.id
-            );
-        } catch (error) {
-            setFusionError({
-                statusCode: error.statusCode,
-                fusionError: error.response as FusionApiHttpErrorResponse,
-            });
-        }
+    const checkContextAccess = React.useCallback(
+        async (contextExternalId: string, contextType: ContextTypes) => {
+            setContextError(null);
+
+            try {
+                await reportApiClient.checkContextAccess(reportId, contextExternalId, contextType);
+            } catch (error) {
+                setContextError({
+                    statusCode: error.statusCode,
+                    fusionError: error.response as FusionApiHttpErrorResponse,
+                });
+            }
+        },
+        [reportApiClient]
+    );
+
+    React.useEffect(() => {
+        if (
+            !contextAccessCheck ||
+            !currentContext?.externalId ||
+            !embedInfo?.embedConfig.rlsConfiguration
+        )
+            return;
+
+        checkContextAccess(currentContext?.externalId, currentContext.type.id);
     }, [currentContext?.id, embedInfo?.embedConfig.rlsConfiguration]);
-
-    React.useEffect(() => {
-        checkContextAccess();
-    }, [currentContext?.id, embedInfo?.embedConfig.rlsConfiguration]);
-
-    React.useEffect(() => {
-        if (!embeddedRef.current) return;
-
-        setIsLoading(true);
-
-        embeddedRef.current.reload();
-    }, [currentContext?.id]);
-
-    const applyBookmark = async (bookmark: string, awaitForContextSwitch: boolean) => {
-        const currentReport =
-            embedRef && embedRef.current ? (powerbi.get(embedRef.current) as pbi.Report) : null;
-        if (awaitForContextSwitch) {
-            setAwaitableBookmark(bookmark);
-            return;
-        }
-        if (!currentReport) {
-            return;
-        }
-        return currentReport.bookmarksManager.applyState(bookmark);
-    };
-
-    const captureBookmark = async () => {
-        const currentReport =
-            embedRef && embedRef.current ? (powerbi.get(embedRef.current) as pbi.Report) : null;
-        if (!currentReport) {
-            return;
-        }
-        const bookmark = await currentReport.bookmarksManager.capture();
-        return bookmark.state;
-    };
-
-    const setFilter = async () => {
-        if (!embedRef.current) return;
-
-        const report = powerbi.get(embedRef.current) as pbi.Report;
-        if (!report) return;
-
-        filters ? await report.setFilters(filters) : await report.removeFilters();
-        if (awaitableBookmark) {
-            applyBookmark(awaitableBookmark, false);
-            setAwaitableBookmark(null);
-        }
-    };
-
-    React.useEffect(() => {
-        if (!isLoading) setFilter();
-    }, [isLoading]);
 
     React.useEffect(() => {
         getReportInfo();
     }, []);
-
-    const getConfig = React.useCallback(
-        (type: ResourceType) => {
-            if (!embedInfo) return;
-            const embedConfig = embedInfo.embedConfig;
-            const token = accessToken ? accessToken.token : undefined;
-            let config: pbi.IEmbedConfiguration = {
-                type: type.toLowerCase(),
-                id: getReportOrDashboardId(embedConfig, type),
-                embedUrl: embedConfig.embedUrl,
-                tokenType: getTokenType(embedConfig),
-                accessToken: token,
-            };
-
-            if (type === 'Report') {
-                const settings = {
-                    filterPaneEnabled: false,
-                    navContentPaneEnabled: false,
-                    localeSettings: {
-                        formatLocale: 'en',
-                        language: 'en',
-                    },
-                };
-
-                config.settings = settings;
-                config.permissions = pbi.models.Permissions.All;
-            } else {
-                config.pageView = 'fitToWidth';
-            }
-
-            return config;
-        },
-        [embedInfo, accessToken]
-    );
-
-    const embed = React.useCallback(
-        (node: HTMLDivElement) => {
-            if (embedInfo) {
-                const config = getConfig(embedInfo.embedConfig.embedType);
-                embeddedRef.current = powerbi.embed(node, config);
-                embeddedRef.current.off('loaded');
-                embeddedRef.current.off('error');
-                embeddedRef.current.off('rendered');
-                embeddedRef.current.off('buttonClicked');
-                embeddedRef.current.on('loaded', () => {
-                    telemetryLogger.trackMetric({
-                        name: `${useCurrentApp.name}-EmbedLoadedTime`,
-                        average: (new Date().getTime() - timeLoadStart.getTime()) / 1000,
-                        sampleCount: 1,
-                    });
-
-                    setIsLoading(false);
-                });
-                embeddedRef.current.on('rendered', () => {
-                    telemetryLogger.trackMetric({
-                        name: `${useCurrentApp.name}-EmbedRenderedTime`,
-                        average: (new Date().getTime() - timeLoadStart.getTime()) / 1000,
-                        sampleCount: 1,
-                    });
-                });
-                embeddedRef.current.on('error', (err: ICustomEvent<IError>) => {
-                    if (err && err.detail) {
-                        telemetryLogger.trackException({
-                            error: new Error('Power BI: ' + err.detail.message),
-                        });
-                    }
-                    setPowerBIError(err);
-                    setIsLoading(false);
-                });
-                embeddedRef.current.on(
-                    'buttonClicked',
-                    (button: ICustomEvent<ButtonClickEvent>) => {
-                        if (button?.detail?.title?.toLowerCase() === 'reset filter') {
-                            setReapplyFilter(true);
-                        }
-                    }
-                );
-            }
-        },
-        [embedInfo, accessToken, reportId]
-    );
-
-    /** TODO: add filters for dashboard if needed? */
-    React.useLayoutEffect(() => {
-        const embedType = embedInfo?.embedConfig?.embedType;
-        if (!embeddedRef.current || !embedType) return;
-        switch (embedType) {
-            case 'Report':
-                embeddedRef.current.on('pageChanged', setFilter);
-                return () =>
-                    embeddedRef?.current ? embeddedRef.current.off('pageChanged') : undefined;
-        }
-    }, [filters, embeddedRef.current, embedInfo]);
-
-    React.useEffect(() => {
-        if (!embeddedRef.current) return;
-
-        embeddedRef.current.off('rendered');
-        embeddedRef.current.on('rendered', () => {
-            if (reApplyFilter) setFilter();
-            setReapplyFilter(false);
-        });
-    }, [reApplyFilter]);
 
     React.useEffect(() => {
         if (accessToken) {
@@ -310,9 +131,7 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters, hasContext }
 
             const expires = expiration.getTime() - now.getTime();
 
-            if (timeout) {
-                clearTimeout(timeout);
-            }
+            if (timeout) clearTimeout(timeout);
 
             timeout = setTimeout(async () => {
                 const access = await reportApiClient.getAccessToken(reportId);
@@ -320,22 +139,6 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters, hasContext }
             }, expires - 2 * 1000);
         }
     }, [accessToken, reportId]);
-
-    React.useEffect(() => {
-        if (!isFetching && embedRef.current !== null) {
-            embed(embedRef.current);
-        }
-    }, [embedRef, isFetching, reportId]);
-
-    React.useEffect(() => {
-        if (!isFetching && embedRef.current !== null) {
-            const embededReport = powerbi.get(embedRef.current);
-
-            if (embededReport && accessToken) {
-                embededReport.setAccessToken(accessToken.token);
-            }
-        }
-    }, [embedRef, accessToken, isFetching]);
 
     if (powerBIError || fusionError) {
         //Only handling selected errors from Power BI. As you migh get errors that can be ignored.
@@ -359,13 +162,7 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters, hasContext }
                 );
             default:
                 return report ? (
-                    <ReportErrorMessage
-                        report={report}
-                        contextError={
-                            fusionError?.statusCode === 403 &&
-                            !Boolean(fusionError?.fusionError?.error?.code === 'NotAuthorized')
-                        }
-                    />
+                    <ReportErrorMessage report={report} contextError={false} />
                 ) : (
                     <ErrorMessage
                         hasError={true}
@@ -373,19 +170,33 @@ const PowerBIReport: React.FC<PowerBIProps> = ({ reportId, filters, hasContext }
                     />
                 );
         }
+    } else if (contextError) {
+        return report ? (
+            <ReportErrorMessage report={report} contextError={true} />
+        ) : (
+            <ErrorMessage
+                hasError={true}
+                message={contextError.fusionError?.error?.message || null}
+            />
+        );
     }
 
     return (
         <>
-            {isFetching && <Spinner title={loadingText} floating centered />}
-            {!isFetching && <div className={styles.powerbiContent} ref={embedRef}></div>}
-            <AppSettingsManager
-                captureAppSetting={captureBookmark}
-                applyAppSetting={applyBookmark}
-                hasContext={hasContext}
-                anchorId="pbi-bookmarks-btn"
-                name="Power BI bookmarks"
-            />
+            {isFetching && !embedInfo && !accessToken && (
+                <Spinner title={loadingText} floating centered />
+            )}
+            {!isFetching && embedInfo && accessToken && (
+                <ReportEmbed
+                    reportId={reportId}
+                    embedInfo={embedInfo}
+                    accessToken={accessToken}
+                    setError={setPowerBIError}
+                    currentContext={currentContext}
+                    filters={filters}
+                    hasContext={hasContext}
+                />
+            )}
         </>
     );
 };


### PR DESCRIPTION
New context access check revield an issue when reembedding a report.
If a report was embed. Then the embed was removed and later reembedded.
The embed would fail.
This has been solved by splitting up the component, ensuring the embed gets a full reset when it get embedded.

The entry point will now only handle fetching of report data and access checks and error handling. Everything related to Fusion.
If user has access and all data is found.
The component will use the new ReportEmbed component.
This handles everything PowerBI.
It also implement the bookmarks manager.

The code and implementation should be mostly the same here.
Its only the big index file that has been split up into two.
Making this component abit easier to reason about, as the initial compoent had grown quite large.