### PR TITLE
hotfix: Hanging Garden - export PIXI

### DIFF
--- a/src/components/data/HangingGarden/index.tsx
+++ b/src/components/data/HangingGarden/index.tsx
@@ -103,5 +103,5 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
 
 export { HangingGardenProps, HangingGardenColumn } from './models/HangingGarden';
 export { ItemRenderContext, RenderItem } from './models/RenderContext';
-export { useHangingGardenData, useHangingGardenErrorMessage, useHangingGardenGetData };
+export { useHangingGardenData, useHangingGardenErrorMessage, useHangingGardenGetData, PIXI };
 export default HangingGarden;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
     useHangingGardenData,
     useHangingGardenErrorMessage,
     useHangingGardenGetData,
+    PIXI,
 } from './components/data/HangingGarden';
 
 // General components


### PR DESCRIPTION
exporting PIXI from the garden component. Making it unnecessery to in stall pixi in local app. And you get Models becomes available to developers