### PR TITLE
Tabs - new prop  noScrollGradient.

### DIFF
--- a/src/components/general/Tabs/Tabs.tsx
+++ b/src/components/general/Tabs/Tabs.tsx
@@ -9,6 +9,7 @@ type TabsProps = {
     onChange: (tabKey: string) => void;
     activeTabKey: string;
     children: any;
+    noScrollGradient?: boolean;
 };
 
 type TabContentType = {
@@ -20,39 +21,33 @@ type GradientType = 'left' | 'right' | 'leftAndRight' | null;
 
 const TabContent: React.FC<TabContentType> = ({ children, activeTabKey }) => {
     const active = React.Children.toArray(children).find(
-        child => (child as React.ReactElement).props.tabKey === activeTabKey
+        (child) => (child as React.ReactElement).props.tabKey === activeTabKey
     ) as React.ReactElement | null;
     if (!active) {
         return null;
     }
 
-    const clonedChildren = React.Children.map(active.props.children, child =>
+    const clonedChildren = React.Children.map(active.props.children, (child) =>
         React.cloneElement(child)
     );
     return <div className={styles.tabContent}>{clonedChildren}</div>;
 };
 
-const TabPane: React.FC<TabsProps> = ({ children, onChange, activeTabKey }) => {
+const TabPane: React.FC<TabsProps> = ({ children, onChange, activeTabKey, noScrollGradient }) => {
     const tabsPaneRef = React.useRef<HTMLDivElement | null>(null);
     const activeTabRef = React.useRef<HTMLElement | null>(null);
 
     const checkForGradient = (): GradientType => {
-        if (!tabsPaneRef.current) {
-            return null;
-        }
+        if (noScrollGradient || !tabsPaneRef.current) return null;
 
-        const pane = tabsPaneRef.current;
+        const { scrollLeft, offsetWidth, scrollWidth } = tabsPaneRef.current;
 
-        if (pane.scrollLeft === 0 && pane.offsetWidth < pane.scrollWidth) {
-            return 'right';
-        }
+        if (scrollLeft === 0 && offsetWidth < scrollWidth) return 'right';
 
-        if (pane.scrollLeft != 0 && pane.scrollLeft + pane.offsetWidth < pane.scrollWidth) {
-            return 'leftAndRight';
-        }
-        if (pane.scrollLeft != 0 && pane.scrollLeft + pane.offsetWidth === pane.scrollWidth) {
-            return 'left';
-        }
+        if (scrollLeft != 0 && scrollLeft + offsetWidth < scrollWidth) return 'leftAndRight';
+
+        if (scrollLeft != 0 && scrollLeft + offsetWidth === scrollWidth) return 'left';
+
         return null;
     };
 
@@ -85,11 +80,11 @@ const TabPane: React.FC<TabsProps> = ({ children, onChange, activeTabKey }) => {
         setGradient(checkForGradient);
     }, [activeTabKey, tabsPaneRef]);
 
-    const clonedChildren = React.Children.map(children, child => {
+    const clonedChildren = React.Children.map(children, (child) => {
         const { tabKey } = child.props;
         if (!tabKey) {
             return null;
-        } 
+        }
         return React.cloneElement(child, {
             onChange: (ref: HTMLElement) => {
                 activeTabRef.current = ref;
@@ -108,13 +103,14 @@ const TabPane: React.FC<TabsProps> = ({ children, onChange, activeTabKey }) => {
     );
 };
 
-const Tabs: React.FC<TabsProps> = ({ onChange, activeTabKey, children }) => {
+const Tabs: React.FC<TabsProps> = ({ onChange, activeTabKey, noScrollGradient, children }) => {
     return (
         <div className={styles.tabs}>
             <TabPane
                 children={children}
                 activeTabKey={activeTabKey}
-                onChange={tabKey => onChange(tabKey)}
+                noScrollGradient={noScrollGradient}
+                onChange={(tabKey) => onChange(tabKey)}
             />
 
             <TabContent children={children} activeTabKey={activeTabKey} />


### PR DESCRIPTION
added new prop to Tabs and TabPane, noScrollGradient. 

When there are to many Tabs in a TabPane, the tabs will have a scroll. 
Per standard there is a fadeout gradient on the side where there are tabs outside of view. 

Adding this flag til remove these Gradients, but it does not change the scroll functionality in any way. 