### PR TITLE
Garden - update columns fix

### DIFF
--- a/src/components/data/HangingGarden/renderHooks/useItem.tsx
+++ b/src/components/data/HangingGarden/renderHooks/useItem.tsx
@@ -75,7 +75,7 @@ const useItem = <T extends HangingGardenColumnIndex>() => {
                 'items',
                 item[itemKeyProp as keyof T]
             ) as PIXI.Container;
-            if (!renderedItem) {
+            if (!renderedItem || Object.keys(item).some((key) => item[key] !== renderedItem[key])) {
                 renderedItem = new PIXI.Container();
                 renderedItem;
                 renderedItem.x = x;


### PR DESCRIPTION
Seems like the local cache is not updating on item change, added proposed solution.
NOT TESTED YET