### PR TITLE
Feat: Fullscreen handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,9 +1422,9 @@
       "dev": true
     },
     "@equinor/fusion": {
-      "version": "2.4.20",
-      "resolved": "https://registry.npmjs.org/@equinor/fusion/-/fusion-2.4.20.tgz",
-      "integrity": "sha512-UC6ZwkVnGAthzO2ZMtw4ZQiKlJxpX/NWoAVUuRO/cZk2KO7AxxscrJTwhegQvRJ0W7ZrgaVo+H3blADx0/yYZg==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@equinor/fusion/-/fusion-2.4.15.tgz",
+      "integrity": "sha512-89i7OcVttp2ekK6qgEUm07TMkbBUPfRMWWOQseuMhVED1/IB5V3vckOtC699VeixN+XjFVZ+4BPdQKt6be7D+Q==",
       "dev": true,
       "requires": {
         "@microsoft/applicationinsights-web": "^2.4.3",
@@ -11833,9 +11833,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
       "dev": true,
       "optional": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/fusion-components",
-  "version": "1.4.27",
+  "version": "1.4.28-pr-912.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,9 +1422,9 @@
       "dev": true
     },
     "@equinor/fusion": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@equinor/fusion/-/fusion-2.4.12.tgz",
-      "integrity": "sha512-esGmLdibeNHVqZrVz5CDXoD7vzuGB28WQR7PeSek0FTRZLVPSvDVQhmVC/TDkl8EbU4z3j3SakTXqq6zG6UKHg==",
+      "version": "2.4.20",
+      "resolved": "https://registry.npmjs.org/@equinor/fusion/-/fusion-2.4.20.tgz",
+      "integrity": "sha512-UC6ZwkVnGAthzO2ZMtw4ZQiKlJxpX/NWoAVUuRO/cZk2KO7AxxscrJTwhegQvRJ0W7ZrgaVo+H3blADx0/yYZg==",
       "dev": true,
       "requires": {
         "@microsoft/applicationinsights-web": "^2.4.3",
@@ -3056,43 +3056,43 @@
       "dev": true
     },
     "@microsoft/applicationinsights-analytics-js": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.5.10.tgz",
-      "integrity": "sha512-NhqPLVv068xOgq6TcU2oo3xOSJc90/aFHFBOpzfm4v2aQdskspLjhrEfIPxbAVnw4DBf+LfQMC82oi0aV3iqrA==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.5.11.tgz",
+      "integrity": "sha512-Ug5p/BOpA5hx3Hhsaw+BPXZ6sKsvYrkqK35M8jKRGS/ZVbrqePy+4C8zBimqJKYX7PLXwLoFl803b8hc1i8KVA==",
       "dev": true,
       "requires": {
-        "@microsoft/applicationinsights-common": "2.5.10",
-        "@microsoft/applicationinsights-core-js": "2.5.10",
+        "@microsoft/applicationinsights-common": "2.5.11",
+        "@microsoft/applicationinsights-core-js": "2.5.11",
         "@microsoft/applicationinsights-shims": "1.0.3",
         "@microsoft/dynamicproto-js": "^1.1.0"
       }
     },
     "@microsoft/applicationinsights-channel-js": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.5.10.tgz",
-      "integrity": "sha512-Uq8lZ3M5oHcRYL31PZO5nRyS+iNQkPHXyjAxiNF1W8dtIfGC0Z3Du2N0LQPImq2vsQn5LmrTjMYtePPGYaozMw==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.5.11.tgz",
+      "integrity": "sha512-jKQ03ZwJ1/i4kkFTFG5jfv0AxOeS9VyzVdO21nUO7/N07yVMV/l8BRlEIFdfUi6eCv8cQF2cOTtc9NAqPPy3Og==",
       "dev": true,
       "requires": {
-        "@microsoft/applicationinsights-common": "2.5.10",
-        "@microsoft/applicationinsights-core-js": "2.5.10",
+        "@microsoft/applicationinsights-common": "2.5.11",
+        "@microsoft/applicationinsights-core-js": "2.5.11",
         "@microsoft/applicationinsights-shims": "1.0.3",
         "@microsoft/dynamicproto-js": "^1.1.0"
       }
     },
     "@microsoft/applicationinsights-common": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.5.10.tgz",
-      "integrity": "sha512-5PKfFXAphA21qeUe0fcUYUi7e4UyN9EEddji1uHophJl0x4/xGWsSo/t4y30a4yd2h0X3sY2BpXUcRjK+abvNA==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.5.11.tgz",
+      "integrity": "sha512-laiJ5BeEqOiFltW32JyVHndny4R4QUcgCdl675A+t9YCsVl6y8DUxvSMT9W3AgYFLVGmrIyYSJLL0xnOT97xhg==",
       "dev": true,
       "requires": {
-        "@microsoft/applicationinsights-core-js": "2.5.10",
+        "@microsoft/applicationinsights-core-js": "2.5.11",
         "@microsoft/applicationinsights-shims": "1.0.3"
       }
     },
     "@microsoft/applicationinsights-core-js": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.5.10.tgz",
-      "integrity": "sha512-Ie6bTfpiqXMxmt2b1qTdkpwhGmKl9w2aMMOh0cKOR3QDSK3UifrAMTcJ2gjlHV2CZSb9ib5FGcuLWcMV82OvmA==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.5.11.tgz",
+      "integrity": "sha512-Httm8NiFnb+gwBvMy+RcI1v9M8qu8JqIn6Wht7QnhPwaVBvwYCFLrIfoT0LOjwAGGASmFHueHMSnbboYWmiZjw==",
       "dev": true,
       "requires": {
         "@microsoft/applicationinsights-shims": "1.0.3",
@@ -3100,25 +3100,25 @@
       }
     },
     "@microsoft/applicationinsights-dependencies-js": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.5.10.tgz",
-      "integrity": "sha512-nAXOywEDfwBtmO6zvYqc12SwPEC4wYH5GP4ofQV7e0c218cz32vjg8to5T5MqAbyyCPgPZTvcOCugqVx3UmG3g==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.5.11.tgz",
+      "integrity": "sha512-vye01TID4kpW6MbZIeAUzvNygauJvCu+0TcpwtKVeAoVBKIfnT1cPrI62ynB9e7AbNzm0AJ/Ax+iR0Y6POhEQQ==",
       "dev": true,
       "requires": {
-        "@microsoft/applicationinsights-common": "2.5.10",
-        "@microsoft/applicationinsights-core-js": "2.5.10",
+        "@microsoft/applicationinsights-common": "2.5.11",
+        "@microsoft/applicationinsights-core-js": "2.5.11",
         "@microsoft/applicationinsights-shims": "1.0.3",
         "@microsoft/dynamicproto-js": "^1.1.0"
       }
     },
     "@microsoft/applicationinsights-properties-js": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.5.10.tgz",
-      "integrity": "sha512-oCv1qU+kzTkDNBeZK9ApPmYE1n8psHXc7VitqAKF23u5dzYEi2u5UC4GwOBeWZDSS7tQ10fSjDtEMOWMd2k7vQ==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.5.11.tgz",
+      "integrity": "sha512-3RPunopAvfW4BC/yRIwkGDYwvn1aHn8f4TUzkdEnaeRzaGkU++ag5mPi9AhUC0l2gSUA8ex+TLwFJ8cgcDz5Xg==",
       "dev": true,
       "requires": {
-        "@microsoft/applicationinsights-common": "2.5.10",
-        "@microsoft/applicationinsights-core-js": "2.5.10",
+        "@microsoft/applicationinsights-common": "2.5.11",
+        "@microsoft/applicationinsights-core-js": "2.5.11",
         "@microsoft/applicationinsights-shims": "1.0.3"
       }
     },
@@ -3129,17 +3129,17 @@
       "dev": true
     },
     "@microsoft/applicationinsights-web": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.5.10.tgz",
-      "integrity": "sha512-uaY+Q8Tw1yKxVkBF144BE9l+fiexL+tMwRxgNTKoxKQiEgXHR5FoPqMhUfJ2kxCVJDVHa4LHdyQNXRZYtWsAQw==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.5.11.tgz",
+      "integrity": "sha512-epwFbaMzibFN12YVRDlt6sBoz9fhjk9CI8y13oGH3B3sKM4mOhdrBRMh7YRhjzVz+3ygFTq9rS9IRu2Ozj7a7A==",
       "dev": true,
       "requires": {
-        "@microsoft/applicationinsights-analytics-js": "2.5.10",
-        "@microsoft/applicationinsights-channel-js": "2.5.10",
-        "@microsoft/applicationinsights-common": "2.5.10",
-        "@microsoft/applicationinsights-core-js": "2.5.10",
-        "@microsoft/applicationinsights-dependencies-js": "2.5.10",
-        "@microsoft/applicationinsights-properties-js": "2.5.10",
+        "@microsoft/applicationinsights-analytics-js": "2.5.11",
+        "@microsoft/applicationinsights-channel-js": "2.5.11",
+        "@microsoft/applicationinsights-common": "2.5.11",
+        "@microsoft/applicationinsights-core-js": "2.5.11",
+        "@microsoft/applicationinsights-dependencies-js": "2.5.11",
+        "@microsoft/applicationinsights-properties-js": "2.5.11",
         "@microsoft/applicationinsights-shims": "1.0.3",
         "@microsoft/dynamicproto-js": "^1.1.0"
       }
@@ -3151,9 +3151,9 @@
       "dev": true
     },
     "@microsoft/signalr": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-3.1.10.tgz",
-      "integrity": "sha512-MSPauolAV+pMMwWE3hIJbuDv03v4o3CNGmDjkWCKuL5qhw28Oa9X099oTpTulrqmDX6755cvIWv7EwbyIij4wA==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-3.1.11.tgz",
+      "integrity": "sha512-PA2iueUlpvRnVHj3HQokBmJD2XuoH3eZQvLCKUBjsIQeBPuqnxTAh7AZr/Kh5ni3VLGaLG8Colgbvbw4xUa9JQ==",
       "dev": true,
       "requires": {
         "eventsource": "^1.0.7",
@@ -25297,6 +25297,7 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -25315,6 +25316,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -25347,6 +25349,7 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -25359,6 +25362,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -25409,7 +25413,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "4.0.1",
@@ -25426,6 +25431,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -25435,6 +25441,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -25445,13 +25452,15 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -25485,6 +25494,7 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/fusion-components",
-  "version": "1.4.27",
+  "version": "1.4.28-pr-912.0",
   "description": "Common react components used by fusion core and fusion apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
-    "@equinor/fusion": "^2.4.20",
+    "@equinor/fusion": "^2.4.15",
     "@storybook/addon-actions": "^6.0.21",
     "@storybook/addon-docs": "^6.0.21",
     "@storybook/addon-jest": "^6.0.21",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
-    "@equinor/fusion": "^2.4.12",
+    "@equinor/fusion": "^2.4.20",
     "@storybook/addon-actions": "^6.0.21",
     "@storybook/addon-docs": "^6.0.21",
     "@storybook/addon-jest": "^6.0.21",

--- a/src/components/core/Header/components/FullscreenToggleButton.tsx
+++ b/src/components/core/Header/components/FullscreenToggleButton.tsx
@@ -1,0 +1,32 @@
+import {
+    FullscreenExitIcon,
+    FullscreenIcon,
+    IconButton,
+    useAnchorRef,
+    useFullscreen,
+    useTooltipRef,
+} from '@equinor/fusion-components';
+import * as React from 'react';
+
+export type FullscreenToggleButtonProps = {
+    quickFactScope?: string;
+};
+
+const FullscreenToggleButton: React.FC<FullscreenToggleButtonProps> = ({ quickFactScope }) => {
+    const { toggleFullscreen, isFullscreenActive } = useFullscreen();
+
+    const tooltipRef = useTooltipRef(
+        isFullscreenActive ? 'Exit Fullscreen Mode (F11)' : 'Enter Fullscreen Mode (F11)',
+        'below'
+    );
+
+    useAnchorRef({ ref: tooltipRef, id: 'fullscreen-toggle-btn', scope: quickFactScope });
+
+    return (
+        <IconButton toggler active={isFullscreenActive} onClick={toggleFullscreen} ref={tooltipRef}>
+            {isFullscreenActive ? <FullscreenExitIcon /> : <FullscreenIcon />}
+        </IconButton>
+    );
+};
+
+export default FullscreenToggleButton;

--- a/src/components/core/Header/index.tsx
+++ b/src/components/core/Header/index.tsx
@@ -14,6 +14,7 @@ import ComponentDisplayToggleButton from './components/ComponentDisplayToggleBut
 import CurrentUserButton from './components/CurrentUserButton';
 import { useHorizontalBreakpoint } from '@equinor/fusion-components';
 import AppManifest from '@equinor/fusion/lib/app/AppManifest';
+import FullscreenToggleButton from './components/FullscreenToggleButton';
 
 enum Breakpoints {
     medium = 'medium',
@@ -44,7 +45,14 @@ type FusionHeaderProps = {
     showSettings?: boolean;
 };
 
-const FusionHeader: React.FC<FusionHeaderProps> = ({ start, content, aside, settings, quickFactScope, showSettings }) => {
+const FusionHeader: React.FC<FusionHeaderProps> = ({
+    start,
+    content,
+    aside,
+    settings,
+    quickFactScope,
+    showSettings,
+}) => {
     const {
         refs: { headerContent, headerAppAside },
     } = useFusionContext();
@@ -95,6 +103,7 @@ const FusionHeader: React.FC<FusionHeaderProps> = ({ start, content, aside, sett
                     ref={headerAppAside as React.MutableRefObject<HTMLDivElement | null>}
                     className={styles.asideAppContainer}
                 ></div>
+                <FullscreenToggleButton quickFactScope={quickFactScope} />
                 <ComponentDisplayToggleButton quickFactScope={quickFactScope} />
                 {aside}
                 <CurrentUserButton quickFactScope={quickFactScope} />

--- a/src/components/icons/components/action/FullscreenExitIcon.tsx
+++ b/src/components/icons/components/action/FullscreenExitIcon.tsx
@@ -4,8 +4,8 @@ import useIcon, { IconProps } from '../../../../hooks/useIcon';
 const FullscreenExitIcon = (props: IconProps) => {
     const iconFactory = useIcon(
         <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
+            fillRule="evenodd"
+            clipRule="evenodd"
             d="M5 8h3V5h2v5H5V8zm3 8H5v-2h5v5H8v-3zm6 3h2v-3h3v-2h-5v5zm2-14v3h3v2h-5V5h2z"
             fill="currentColor"
         />

--- a/src/components/icons/components/action/FullscreenExitIcon.tsx
+++ b/src/components/icons/components/action/FullscreenExitIcon.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import useIcon, { IconProps } from '../../../../hooks/useIcon';
+
+const FullscreenExitIcon = (props: IconProps) => {
+    const iconFactory = useIcon(
+        <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M5 8h3V5h2v5H5V8zm3 8H5v-2h5v5H8v-3zm6 3h2v-3h3v-2h-5v5zm2-14v3h3v2h-5V5h2z"
+            fill="currentColor"
+        />
+    );
+
+    return iconFactory(props);
+};
+
+export default FullscreenExitIcon;

--- a/src/components/icons/components/action/FullscreenIcon.tsx
+++ b/src/components/icons/components/action/FullscreenIcon.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import useIcon, { IconProps } from '../../../../hooks/useIcon';
+
+const FullscreenIcon = (props: IconProps) => {
+    const iconFactory = useIcon(
+        <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M7 10H5V5h5v2H7v3zm-2 4h2v3h3v2H5v-5zm12 3h-3v2h5v-5h-2v3zM14 7V5h5v5h-2V7h-3z"
+            fill="currentColor"
+        />
+    );
+
+    return iconFactory(props);
+};
+
+export default FullscreenIcon;

--- a/src/components/icons/components/action/FullscreenIcon.tsx
+++ b/src/components/icons/components/action/FullscreenIcon.tsx
@@ -4,8 +4,8 @@ import useIcon, { IconProps } from '../../../../hooks/useIcon';
 const FullscreenIcon = (props: IconProps) => {
     const iconFactory = useIcon(
         <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
+            fillRule="evenodd"
+            clipRule="evenodd"
             d="M7 10H5V5h5v2H7v3zm-2 4h2v3h3v2H5v-5zm12 3h-3v2h5v-5h-2v3zM14 7V5h5v5h-2V7h-3z"
             fill="currentColor"
         />

--- a/src/components/icons/components/action/index.ts
+++ b/src/components/icons/components/action/index.ts
@@ -19,3 +19,5 @@ export { default as ScheduleIcon } from './ScheduleIcon';
 export { default as BookmarksIcon } from './BookmarksIcon';
 export { default as CalendarAcceptIcon } from './CalendarAcceptIcon';
 export { default as CalendarEventIcon } from './CalendarEventIcon';
+export { default as FullscreenIcon } from './FullscreenIcon';
+export { default as FullscreenExitIcon } from './FullscreenExitIcon';

--- a/src/hooks/useFullscreen.tsx
+++ b/src/hooks/useFullscreen.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+/**
+ * Give you tools to handle fullscreen mode using buttons or other means than the usual F11 button.
+ * Per default the hook will set entire Fusion into fullscreen, but this can be changed by passing in a ref to another element
+ * @param elementRef a ref to specific element on page you want to set into fullscreen mode.
+ */
+
+const useFullscreen = (elementRef?: React.RefObject<HTMLElement> | null) => {
+    const [isFullscreenActive, setIsFullscreenActive] = React.useState(
+        Boolean(document.fullscreenElement)
+    );
+
+    const element = elementRef ?? React.useRef(document.getElementById('app'));
+
+    const checkIsFullscreenActive = React.useCallback(() => {
+        setIsFullscreenActive(Boolean(document.fullscreenElement));
+    }, [document]);
+
+    const requestFullscreen = React.useCallback(() => element.current?.requestFullscreen(), [
+        element,
+    ]);
+
+    const exitFullscreen = React.useCallback(() => document.exitFullscreen(), [document]);
+
+    const toggleFullscreen = React.useCallback(() => {
+        isFullscreenActive ? exitFullscreen() : requestFullscreen();
+    }, [isFullscreenActive, requestFullscreen, exitFullscreen]);
+
+    React.useEffect(() => {
+        element.current?.addEventListener('fullscreenchange', checkIsFullscreenActive);
+        return () =>
+            element.current?.removeEventListener('fullscreenchange', checkIsFullscreenActive);
+    }, []);
+
+    return { toggleFullscreen, requestFullscreen, exitFullscreen, isFullscreenActive };
+};
+
+export default useFullscreen;

--- a/src/hooks/useFullscreen.tsx
+++ b/src/hooks/useFullscreen.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 /**
  * Give you tools to handle fullscreen mode using buttons or other means than the usual F11 button.
- * Per default the hook will set entire Fusion into fullscreen, but this can be changed by passing in a ref to another element
+ * Per default the hook will fullscreen the body tag, but this can be changed by passing in a ref to another element
  * @param elementRef a ref to specific element on page you want to set into fullscreen mode.
  */
 
@@ -11,7 +11,7 @@ const useFullscreen = (elementRef?: React.RefObject<HTMLElement> | null) => {
         Boolean(document.fullscreenElement)
     );
 
-    const element = elementRef ?? React.useRef(document.getElementById('app'));
+    const element = elementRef ?? React.useRef(document.body);
 
     const checkIsFullscreenActive = React.useCallback(() => {
         setIsFullscreenActive(Boolean(document.fullscreenElement));

--- a/src/hooks/useFullscreen.tsx
+++ b/src/hooks/useFullscreen.tsx
@@ -23,13 +23,17 @@ const useFullscreen = (elementRef?: React.RefObject<HTMLElement> | null) => {
 
     const requestFullscreen = React.useCallback(
         () =>
-            element.current?.requestFullscreen() ??
-            (element.current as any).webkitRequestFullscreen(),
+            element.current.requestFullscreen
+                ? element.current.requestFullscreen()
+                : (element.current as any).webkitRequestFullscreen(),
         [element]
     );
 
     const exitFullscreen = React.useCallback(
-        () => document?.exitFullscreen() ?? (document as any)?.webkitExitFullscreen(),
+        () =>
+            document?.exitFullscreen
+                ? document?.exitFullscreen()
+                : (document as any)?.webkitExitFullscreen(),
         [document]
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ export { default as useHorizontalBreakpoint } from './hooks/useHorizontalBreakpo
 export { default as useSizeBreakpoint } from './hooks/useSizeBreakpoint';
 export { default as useVerticalBreakpoint } from './hooks/useVerticalBreakpoint';
 export { default as useRootContainer } from './hooks/useRootContainer';
+export { default as useFullscreen } from './hooks/useFullscreen';
 export {
     default as useStringMask,
     applyStringMask,
@@ -186,6 +187,8 @@ export {
     BookmarksIcon,
     CalendarAcceptIcon,
     CalendarEventIcon,
+    FullscreenIcon,
+    FullscreenExitIcon,
 } from './components/icons/components/action';
 export {
     PaginationArrow,


### PR DESCRIPTION
New hook useFullscreen : standardized use off fullscreen API. 
Can be used stand alone to set a specific element in an app to be fullscreen. 
Per default the implementation fullscreens the body of the website. Which is the general "F11" behaviour. 

Added new 'Fullscreen Toggle button" to Fusion Header. 
Used to toggle fusion between fullscreen and not. 

Added new icons used by the fullscreen button. 