### PR TITLE
fix: filter pane - remove remove filters when pane is collapsed

### DIFF
--- a/src/components/general/FilterPane/index.tsx
+++ b/src/components/general/FilterPane/index.tsx
@@ -122,7 +122,7 @@ function FilterPane<T>({
                     {!isCollapsed && headerComponent}
                 </div>
                 <div className={styles.content}>
-                    {showResetAllButton && (
+                    {showResetAllButton && !isCollapsed && (
                         <div className={styles.resetButton}>
                             <Button frameless onClick={onClick}>
                                 Reset filters


### PR DESCRIPTION
added back the isCollapsed clause for reset button. Else it stay when  pane is collapsed and it looks very out of place