### PR TITLE
Powert BI Report - Extended Error Handling

### DIFF
--- a/src/components/data/PowerBIReport/index.tsx
+++ b/src/components/data/PowerBIReport/index.tsx
@@ -194,11 +194,19 @@ const PowerBIReport: FC<PowerBIProps> = ({ reportId, filters, hasContext }) => {
         );
         switch (Number(code)) {
             case 403: {
-                if (report) {
-                    // TODO: is there not a better way to check this?
-                    const hasContext = (inner as FusionApiErrorMessage)?.code !== 'NotAuthorized';
-                    return <ReportErrorMessage report={report} contextError={hasContext} />;
-                }
+                if (report && (inner as FusionApiErrorMessage)?.code === 'NotAuthorized')
+                    return <ReportErrorMessage report={report} contextError={true} />;
+
+                if ((inner as FusionApiErrorMessage)?.code === 'MissingContextRelation')
+                    return (
+                        <ErrorMessage
+                            hasError={true}
+                            errorType={'noData'}
+                            title={'No data available for selected context'}
+                            message={(inner as FusionApiErrorMessage)?.message || message}
+                        />
+                    );
+
                 return renderStandardError('accessDenied');
             }
 


### PR DESCRIPTION
Added error handling for MissingContextRelation.
This happens when the selected context is not setup for use in procosys.
Also revised the NotAuthorized error message. The error now always refers no contex access instead of report.
Been a minor misunderstanding on this one.