### PR TITLE
Power BI - Further improvements to Error Handling

### DIFF
--- a/src/components/data/PowerBIReport/components/ReportErrorMessage/index.tsx
+++ b/src/components/data/PowerBIReport/components/ReportErrorMessage/index.tsx
@@ -67,7 +67,7 @@ const ReportErrorMessage: FC<ReportErrorMessageProps> = ({ report, contextErrorT
         setRequirements(null);
         setNoAccessMessage(message || null);
         setIsFetching(false);
-    }, [report.id]);
+    }, [report.id, message]);
 
     const getReportInformation = useCallback(async () => {
         setIsFetching(true);

--- a/src/components/data/PowerBIReport/index.tsx
+++ b/src/components/data/PowerBIReport/index.tsx
@@ -139,6 +139,7 @@ const PowerBIReport: FC<PowerBIProps> = ({ reportId, filters, hasContext }) => {
 
     const checkContextAccess = useCallback(async () => {
         if (!currentContext?.externalId || !embedInfo?.embedConfig.rlsConfiguration) return;
+        setError(null);
         try {
             await reportApiClient.checkContextAccess(
                 reportId,
@@ -157,9 +158,8 @@ const PowerBIReport: FC<PowerBIProps> = ({ reportId, filters, hasContext }) => {
     }, [currentContext, embedInfo?.embedConfig.rlsConfiguration]);
 
     useEffect(() => {
-        setError(null);
-        accessToken ? checkContextAccess() : getReportInfo();
-    }, [currentContext, embedInfo?.embedConfig.rlsConfiguration]);
+        accessToken && checkContextAccess();
+    }, [currentContext, accessToken, embedInfo?.embedConfig.rlsConfiguration]);
 
     useEffect(() => {
         getReportInfo();
@@ -202,18 +202,24 @@ const PowerBIReport: FC<PowerBIProps> = ({ reportId, filters, hasContext }) => {
         switch (Number(code)) {
             case 403: {
                 if (report && error.message === 'NotAuthorizedReport')
-                    return <ReportErrorMessage report={report} contextError={false} />;
+                    return (
+                        <ReportErrorMessage
+                            report={report}
+                            contextErrorType={'NotAuthorizedReport'}
+                        />
+                    );
 
                 if (report && (inner as FusionApiErrorMessage)?.code === 'NotAuthorized')
-                    return <ReportErrorMessage report={report} contextError={true} />;
-
-                if ((inner as FusionApiErrorMessage)?.code === 'MissingContextRelation')
                     return (
-                        <ErrorMessage
-                            hasError={true}
-                            errorType={'noData'}
-                            title={'No data available for selected context'}
-                            message={(inner as FusionApiErrorMessage)?.message || message}
+                        <ReportErrorMessage report={report} contextErrorType={'NotAuthorized'} />
+                    );
+
+                if (report && (inner as FusionApiErrorMessage)?.code === 'MissingContextRelation')
+                    return (
+                        <ReportErrorMessage
+                            report={report}
+                            contextErrorType={'MissingContextRelation'}
+                            message={(inner as FusionApiErrorMessage)?.message}
                         />
                     );
 


### PR DESCRIPTION
Fixed issue where changing user would get a white screen when changing context, if user does not have access to report or report does not have RLS Configuration
This happended because the useEffect removed error before checking if the checkContextAccess was even going to run. 
Leaving the user with no error on screen. 
Now the reset for error does not happen before we know checkContextAccess is going to run. 
Also checkContextAccess will not run if there is no accessToken, as there is no need to check this if user does not have access to the report at all. 
This makes sure the no report access takes precedence over no context error. 

Further the ReportErrorMessage component has been extended to facilitate an extra error from the checkContextAccess, "MissingContextRelation" 

