### PR TITLE
Render bookmark component after powerbi is rendered

### DIFF
--- a/src/components/data/PowerBIReport/components/ReportEmbed/index.tsx
+++ b/src/components/data/PowerBIReport/components/ReportEmbed/index.tsx
@@ -68,7 +68,7 @@ const ReportEmbed: FC<PowerBIProps> = ({
     const embedRef = useRef<HTMLDivElement>(null);
     const embeddedRef = useRef<pbi.Embed | null>(null);
     const [awaitableBookmark, setAwaitableBookmark] = useState<string | null>(null);
-
+    const [isRendering, setIsRendering] = useState<boolean>(true);
     const applyBookmark = async (bookmark: string, awaitForContextSwitch: boolean) => {
         const currentReport =
             embedRef && embedRef.current ? (powerbi.get(embedRef.current) as pbi.Report) : null;
@@ -162,6 +162,7 @@ const ReportEmbed: FC<PowerBIProps> = ({
                     setIsLoading(false);
                 });
                 embeddedRef.current.on('rendered', () => {
+                    setIsRendering(false);
                     telemetryLogger.trackMetric({
                         name: `pbi.report.render`,
                         properties: {
@@ -251,14 +252,16 @@ const ReportEmbed: FC<PowerBIProps> = ({
     return (
         <>
             <div className={styles.powerbiContent} ref={embedRef}></div>
-            <BookmarksManager
-                applyBookmark={(bookmark, awaitForContextSwitch) =>
-                    applyBookmark(bookmark.payload, awaitForContextSwitch)
-                }
-                anchorId="pbi-bookmarks-btn"
-                name="Power BI bookmarks"
-                capturePayload={captureBookmark}
-            />
+            {!isRendering && (
+                <BookmarksManager
+                    applyBookmark={(bookmark, awaitForContextSwitch) =>
+                        applyBookmark(bookmark.payload, awaitForContextSwitch)
+                    }
+                    anchorId="pbi-bookmarks-btn"
+                    name="Power BI bookmarks"
+                    capturePayload={captureBookmark}
+                />
+            )}
         </>
     );
 };


### PR DESCRIPTION
When sharing a bookmark and using the shared URL, the bookmark component has to wait for the Power BI report to be rendered  so the bookmark can be applied to the data set.