### PR TITLE
Remove odata query for Person components

### DIFF
--- a/src/components/people/PersonCard/index.tsx
+++ b/src/components/people/PersonCard/index.tsx
@@ -10,7 +10,6 @@ import classNames from 'classnames';
 import styles from './styles.less';
 import {
     PersonDetails,
-    usePersonDetails,
     useComponentDisplayClassNames,
     useComponentDisplayType,
     ComponentDisplayType,
@@ -18,6 +17,7 @@ import {
 import { getDefaultPerson } from '../utils';
 import PersonDetail from '../PersonDetail';
 import { SkeletonBar } from '../../feedback/Skeleton';
+import usePeopleDetails from '../usePeopleDetails';
 
 export { PhotoSize };
 
@@ -42,7 +42,7 @@ export default ({
 }: PersonCardProps) => {
     const [currentPerson, setCurrentPerson] = useState<PersonDetails>();
     const { isFetching, error, personDetails } = personId
-        ? usePersonDetails(personId)
+        ? usePeopleDetails(personId)
         : { isFetching: isFetchingPerson, error: null, personDetails: person };
 
     useEffect(() => {

--- a/src/components/people/PersonDetail/index.tsx
+++ b/src/components/people/PersonDetail/index.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useState, Fragment } from 'react';
 
 import styles from './styles.less';
-import { PersonDetails, usePersonDetails, PersonPresence, useApiClients } from '@equinor/fusion';
+import { PersonDetails, PersonPresence, useApiClients } from '@equinor/fusion';
 import {
     PersonPhoto,
     PersonPresenceIcon,
     AccountTypeIcon,
     SkeletonBar,
 } from '@equinor/fusion-components';
+import usePeopleDetails from '../usePeopleDetails';
 
 export type PersonDetailProps = {
     personId?: string;
@@ -23,7 +24,7 @@ export default ({ personId, person, noPhoto }: PersonDetailProps) => {
     const apiClients = useApiClients();
 
     const { error, personDetails, isFetching } = personId
-        ? usePersonDetails(personId)
+        ? usePeopleDetails(personId)
         : { error: null, personDetails: person, isFetching: false };
 
     useEffect(() => {

--- a/src/components/people/PersonPhoto/index.tsx
+++ b/src/components/people/PersonPhoto/index.tsx
@@ -3,7 +3,6 @@ import styles from './styles.less';
 import classNames from 'classnames';
 import {
     useComponentDisplayClassNames,
-    usePersonDetails,
     PersonDetails,
     usePersonImageUrl,
     PersonPresenceAvailability,
@@ -17,6 +16,7 @@ import PersonDetail from '../PersonDetail';
 import { SkeletonDisc } from '../../feedback/Skeleton';
 import PersonPresenceIcon from './PersonPresenceIcon';
 import AccountTypeIcon from './AccountTypeIcon';
+import usePeopleDetails from '../usePeopleDetails';
 
 export { PersonPresenceIcon, AccountTypeIcon };
 
@@ -61,7 +61,7 @@ export default ({
     const { isFetching, imageUrl, error: imageError } = usePersonImageUrl(id);
 
     const { error, personDetails } = personId
-        ? usePersonDetails(personId)
+        ? usePeopleDetails(personId)
         : { error: null, personDetails: person };
 
     useEffect(() => {

--- a/src/components/people/usePeopleDetails.ts
+++ b/src/components/people/usePeopleDetails.ts
@@ -1,0 +1,35 @@
+import { useState, useCallback, useEffect } from 'react';
+import { PersonDetails, useFusionContext } from '@equinor/fusion';
+
+export const usePeopleDetails = (personId?: string) => {
+    const [isFetching, setIsFetching] = useState(false);
+    const [personDetails, setPersonDetails] = useState<PersonDetails | null>(null);
+    const [error, setError] = useState<Error | null>(null);
+    const fusionContext = useFusionContext();
+
+    const fetchPersonData = useCallback(async (personId: string) => {
+        setIsFetching(true);
+        setPersonDetails(null);
+        try {
+            const response = await fusionContext.http.apiClients.people.getPersonDetailsAsync(
+                personId
+            );
+            setPersonDetails(response.data);
+            setIsFetching(false);
+        } catch (e) {
+            setPersonDetails(null);
+            setIsFetching(false);
+            setError(e);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (personId) {
+            fetchPersonData(personId);
+        }
+    }, [fetchPersonData, personId]);
+
+    return { personDetails, isFetching, error };
+};
+
+export default usePeopleDetails;


### PR DESCRIPTION
A hook for retrieving a person's details without the odata queries (roles, contracts, positions). The old hook from fusion-api contains all of these three. I could remove them from the fusion-api, however some app may be dependent on them.