### PR TITLE
Change PersonPhoto tooltips

### DIFF
--- a/src/components/people/PersonPhoto/AccountTypeBadge.tsx
+++ b/src/components/people/PersonPhoto/AccountTypeBadge.tsx
@@ -16,7 +16,6 @@ import EmployeeIcon from './icons/EmployeeIcon';
 type AccountTypeBageProps = {
     size: PhotoSize;
     currentPerson: PersonDetails;
-    hideTooltip?: boolean;
 };
 
 const getIconSizes = (isCompact: boolean) => ({
@@ -26,25 +25,7 @@ const getIconSizes = (isCompact: boolean) => ({
     small: isCompact ? 8 : 12,
 });
 
-const resolveTooltip = (accountType: string, isExternalHire: boolean) => {
-    switch (accountType) {
-        case 'Local':
-            return 'No affiliate access account. User cannot log in to Fusion';
-        case 'Employee':
-            if (isExternalHire) {
-                return 'External hire';
-            }
-            return 'Equinor employee';
-        case 'External':
-            return 'Affiliate access';
-        case 'Consultant':
-            return 'X-External / External with Equinor account';
-        default:
-            return accountType;
-    }
-};
-
-const AccountTypeBadge = ({ size, currentPerson, hideTooltip }: AccountTypeBageProps) => {
+const AccountTypeBadge = ({ size, currentPerson }: AccountTypeBageProps) => {
     const isExternalHire = !!(
         currentPerson.jobTitle && currentPerson.jobTitle.toLowerCase().startsWith('ext')
     );
@@ -67,12 +48,9 @@ const AccountTypeBadge = ({ size, currentPerson, hideTooltip }: AccountTypeBageP
 
     const displayType = useComponentDisplayType();
     const iconSize = getIconSizes(displayType === ComponentDisplayType.Compact)[size];
-    const accountTypeTooltipRef = useTooltipRef(
-        hideTooltip ? '' : resolveTooltip(currentPerson.accountType, isExternalHire)
-    );
 
     return (
-        <div className={iconClassNames} ref={accountTypeTooltipRef}>
+        <div className={iconClassNames}>
             {isConsultant && <ConsultantIcon width={iconSize} height={iconSize} />}
             {isExternalHire && <ExternalHireIcon width={iconSize} height={iconSize} />}
             {isExternal && <AffiliateIcon width={iconSize} height={iconSize} />}

--- a/src/components/people/PersonPhoto/AccountTypeIcon/index.tsx
+++ b/src/components/people/PersonPhoto/AccountTypeIcon/index.tsx
@@ -26,24 +26,6 @@ const getIconSizes = (isCompact: boolean) => ({
     small: isCompact ? 8 : 12,
 });
 
-const resolveTooltip = (accountType: string, isExternalHire: boolean) => {
-    switch (accountType) {
-        case 'Local':
-            return 'No affiliate access account. User cannot log in to Fusion';
-        case 'Employee':
-            if (isExternalHire) {
-                return 'External hire';
-            }
-            return 'Equinor employee';
-        case 'External':
-            return 'Affiliate access';
-        case 'Consultant':
-            return 'X-External / External with Equinor account';
-        default:
-            return accountType;
-    }
-};
-
 const AccountTypeIkon = ({ size, currentPerson, hideTooltip }: AccountTypeIkonProps) => {
     const isExternalHire = !!(
         currentPerson.jobTitle && currentPerson.jobTitle.toLowerCase().startsWith('ext')
@@ -67,12 +49,9 @@ const AccountTypeIkon = ({ size, currentPerson, hideTooltip }: AccountTypeIkonPr
 
     const displayType = useComponentDisplayType();
     const iconSize = getIconSizes(displayType === ComponentDisplayType.Compact)[size];
-    const accountTypeTooltipRef = useTooltipRef(
-        hideTooltip ? '' : resolveTooltip(currentPerson.accountType, isExternalHire)
-    );
 
     return (
-        <div className={iconClassNames} ref={accountTypeTooltipRef}>
+        <div className={iconClassNames}>
             {isConsultant && <ConsultantIcon width={iconSize} height={iconSize} />}
             {isExternalHire && <ExternalHireIcon width={iconSize} height={iconSize} />}
             {isExternal && <AffiliateIcon width={iconSize} height={iconSize} />}

--- a/src/components/people/PersonPhoto/index.tsx
+++ b/src/components/people/PersonPhoto/index.tsx
@@ -153,11 +153,7 @@ export default ({
                         <FallbackImage size={size} rotation={additionalPersons.length > 0} />
                     )}
                     {personDetails && additionalPersons.length === 0 && (
-                        <AccountTypeBadge
-                            currentPerson={personDetails}
-                            size={size}
-                            hideTooltip={hideTooltip}
-                        />
+                        <AccountTypeBadge currentPerson={personDetails} size={size} />
                     )}
                     {additionalPersons.length > 0 && (
                         <RotationBadge

--- a/src/components/people/PersonPhoto/index.tsx
+++ b/src/components/people/PersonPhoto/index.tsx
@@ -45,7 +45,7 @@ export default ({
 
     const id = person && additionalPersons.length === 0 ? person.azureUniqueId : personId || '';
 
-    const { imageUrl, error: imageError } = usePersonImageUrl(id);
+    const { isFetching, imageUrl, error: imageError } = usePersonImageUrl(id);
 
     const { error, personDetails, isFetching: fetching } = personId
         ? usePeopleDetails(personId)
@@ -107,7 +107,13 @@ export default ({
             return popoverRef;
         }
     };
-
+    if (isFetching) {
+        return (
+            <div className={photoClassNames}>
+                <SkeletonDisc size={size} />
+            </div>
+        );
+    }
     return (
         <div
             ref={hidePopover ? undefined : refCheck()}


### PR DESCRIPTION
## Summary:

* AccountTypeBadge: Remove the resolver for employee tooltip as well as the ref for the tooltip.
* AccountTypeIcon: Same as AccountTypeBadge
* When hovering the employee icon on a person photo, the employee tooltip will not appear. Instead a popover with more information about the person will appear.

Instead of having two tooltips (tooltip and popover) on two different div-tags, I have now changed the logic to be either or.
The refCheck handles this logic; If there are multiple people or no assigned person it will return the tooltip, and if there is one assigned person it will return the popover.

The tooltip will look like this when hovering a person photo that has not been assigned yet, or if there are additional people:
![tbn](https://user-images.githubusercontent.com/28650210/120325672-2ee6a200-c2e8-11eb-8676-cc8c9893ef68.PNG)

The popover will look like this when hovering an assigned person:

![popover](https://user-images.githubusercontent.com/28650210/120326225-cba93f80-c2e8-11eb-82ae-169386d13e66.PNG)

