### PR TITLE
fix: Filter Pane - Filters collapse on selection/ term update 

### DIFF
--- a/src/components/general/FilterPane/components/Filter.tsx
+++ b/src/components/general/FilterPane/components/Filter.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, FC } from 'react';
+import { useState, useCallback, useMemo, FC, useEffect } from 'react';
 
 import classNames from 'classnames';
 import {
@@ -99,6 +99,10 @@ function Filter<T>({
 }: FilterProps<T>) {
     const [term, setTerm] = useState<FilterTerm | null>(defaultTerm || null);
     const [isCollapsed, setIsCollapsed] = useState(filter.isCollapsed);
+
+    useEffect(() => {
+        defaultTerm && setTerm(defaultTerm);
+    }, [defaultTerm]);
 
     const handleOnChange = useCallback(
         (newValue) => {

--- a/src/components/general/FilterPane/components/Section.tsx
+++ b/src/components/general/FilterPane/components/Section.tsx
@@ -44,11 +44,7 @@ function Section<T>({ terms, filterCount, section, onChange, quickFactScope }: S
             const term = terms.find((term) => term.key === filter.key);
             return (
                 <Filter
-                    key={
-                        filter.type === FilterTypes.Search
-                            ? filter.key
-                            : `${filter.key}_${term?.value}`
-                    }
+                    key={filter.key}
                     filter={filter}
                     term={term}
                     filterCount={filterCount}


### PR DESCRIPTION
Reverted previous change where  Filter key was set to  changed based on terms updates.
As this caused the Filter to be recreated for each change/selection, making it loose its internal state.
Most notably, this causes the filter to collapse each time a user makes a selection.

This changes was made to fix an issue where filters was not updating when user were applying Bookmarks.
I have made an alternative solution to this inside the Filter component itself.
It will now update based on defaultTerm. So if the filter selection get updated from outside the filter component. It will update its interal term state, reflecting these changes.