### PR TITLE
fix: FilterPane - reset filters that are not part of bookmark 

### DIFF
--- a/src/components/general/FilterPane/components/Filter.tsx
+++ b/src/components/general/FilterPane/components/Filter.tsx
@@ -101,7 +101,7 @@ function Filter<T>({
     const [isCollapsed, setIsCollapsed] = useState(filter.isCollapsed);
 
     useEffect(() => {
-        defaultTerm && setTerm(defaultTerm);
+        setTerm(defaultTerm || null);
     }, [defaultTerm]);
 
     const handleOnChange = useCallback(


### PR DESCRIPTION
if user applied a bookmark, after selecting filters not part of the bookmark. Those filter was not updated or reset visually