### PR TITLE
Adjust height for messages in ErrorMessage component

### DIFF
--- a/src/components/general/ErrorMessage/styles.less
+++ b/src/components/general/ErrorMessage/styles.less
@@ -35,8 +35,9 @@
             .message {
                 font-size: 20px;
                 height: calc(var(--grid-unit) * 3px);
-                padding-bottom: calc(var(--grid-unit) * 10px);
+                padding-bottom: calc(var(--grid-unit) * 5px);
                 padding-top: calc(var(--grid-unit) * 3px);
+                height: auto;
             }
         }
 
@@ -57,6 +58,7 @@
                 height: calc(var(--grid-unit) * 2px);
                 padding-bottom: calc(var(--grid-unit) * 4px);
                 padding-top: calc(var(--grid-unit) * 1px);
+                height: auto;
             }
         }
     }


### PR DESCRIPTION
The message prop in ErrorMessage needed a heigh so it will not overlap the "action" button.