### PR TITLE
usePopoverRef - Open state mismatch 

### DIFF
--- a/src/hooks/usePopoverRef/index.tsx
+++ b/src/hooks/usePopoverRef/index.tsx
@@ -36,6 +36,10 @@ export default <T extends HTMLElement>(
         ? useHoverToggleController<T>()
         : useClickToggleController<T>();
 
+    useEffect(() => {
+        setIsPopoverOpen(isOpen);
+    }, [isOpen]);
+
     const [isContentOpen, popoverContentRef] = useHoverToggleController<HTMLDivElement>();
 
     const rect = useRelativePositioning(ref);


### PR DESCRIPTION
usePopoverRef returns setIsOpen, where you can close the popover outside the component.
When this is done, isPopoverOpen state is not updated. This create a mismatch between the useToggleController open state and internal open state.
And the user needs to double click the ref again next time to get the popover to open.
This fix forces the isPopoverOpen to align with isOpen.