### PR TITLE
fix: usePopoverRef - stop setIsPopoverOpen when using hover

### DIFF
--- a/src/hooks/usePopoverRef/index.tsx
+++ b/src/hooks/usePopoverRef/index.tsx
@@ -37,7 +37,9 @@ export default <T extends HTMLElement>(
         : useClickToggleController<T>();
 
     useEffect(() => {
-        setIsPopoverOpen(isOpen);
+        if (hover) return;
+
+        setIsPopoverOpen?.(isOpen);
     }, [isOpen]);
 
     const [isContentOpen, popoverContentRef] = useHoverToggleController<HTMLDivElement>();


### PR DESCRIPTION
useHoverToogleController does not return a setState handler. Causing useEffect to fail when, using the hook.

Added a handler where, it just returns if its a hover, and a redundant check on weither setIsPopoverOpen when calling function.