### PR TITLE
feat: 30% opacity when inactive prop PersonDetails

### DIFF
--- a/src/components/people/PersonDetail/index.tsx
+++ b/src/components/people/PersonDetail/index.tsx
@@ -69,7 +69,7 @@ export default ({ personId, person, noPhoto }: PersonDetailProps) => {
                                     size="xlarge"
                                 />
                             </div>
-                            {presence?.availability || 'Unknown'}
+                            {!!currentPerson.inactive ? 'Inactive Account' : presence?.availability || 'Unknown'}
                         </div>
                         <div className={styles.detailSection}>
                             {isFetching ? (

--- a/src/components/people/PersonPhoto/__stories__/PersonPhoto.stories.tsx
+++ b/src/components/people/PersonPhoto/__stories__/PersonPhoto.stories.tsx
@@ -50,6 +50,7 @@ const persons: PersonDictionary = {
         accountType: 'External',
         name: 'External Person',
         mail: 'external@gmail.com',
+        inactive: true,
     },
     Local: {
         ...basePerson,
@@ -72,7 +73,7 @@ const sizes = {
     small: 'small',
 };
 
-const PersonPhotoStory = () => {
+const DefaultPersonPhotoStory = () => {
     const personKey = select('Account type', personKeys, personKeys.Consultant);
     const person = persons[personKey];
 
@@ -81,4 +82,15 @@ const PersonPhotoStory = () => {
     return <PersonPhoto hideTooltip={boolean('Hide tooltip', true)} person={person} size={size} />;
 };
 
-stories.add('Default', () => <PersonPhotoStory />);
+const InactivePersonPhotoStory = () => {
+    const personKey = select('Account type', personKeys, personKeys.External);
+    const person = persons[personKey];
+
+    const size = select('Size', sizes, sizes.xlarge) as PhotoSize;
+
+    return <PersonPhoto hideTooltip={boolean('Hide tooltip', true)} person={person} size={size} />;
+};
+
+stories
+    .add('Default', () => <DefaultPersonPhotoStory />)
+    .add('Inactive', () => <InactivePersonPhotoStory />);

--- a/src/components/people/PersonPhoto/index.tsx
+++ b/src/components/people/PersonPhoto/index.tsx
@@ -65,6 +65,7 @@ export default ({
             [styles.large]: size === 'large',
             [styles.medium]: size === 'medium',
             [styles.small]: size === 'small',
+            [styles.inactive]: !!currentPerson?.inactive,
         }
     );
 

--- a/src/components/people/PersonPhoto/styles.less
+++ b/src/components/people/PersonPhoto/styles.less
@@ -124,4 +124,8 @@
             }
         }
     }
+
+    &.inactive {
+        opacity: 30%;
+    }
 }


### PR DESCRIPTION
https://dev.azure.com/statoil-proview/Fusion/_backlogs/backlog/Fusion%20Team/Epics/?showParents=true&workitem=20992

As linked task implies, there is a need to indicate if a persons account is inactive.