### PR TITLE
fix: dropdown and scrim refs and click handlers

### DIFF
--- a/src/components/general/Dropdown/index.tsx
+++ b/src/components/general/Dropdown/index.tsx
@@ -2,7 +2,6 @@ import { useState, useRef, useCallback, FC, useEffect, MutableRefObject, ReactNo
 
 import classNames from 'classnames';
 import {
-    useClickOutsideOverlayPortal,
     RelativeOverlayPortal,
     useElevationClassName,
     useRelativePositioning,
@@ -68,7 +67,6 @@ const Dropdown: FC<DropdownProps> = ({ controller, justification, children }) =>
     const { isOpen, setIsOpen, node, controllerRef } = controller;
 
     const close = useCallback(() => isOpen && setIsOpen(false), [isOpen]);
-    useClickOutsideOverlayPortal(close, controllerRef.current);
 
     const dropdownContainerClassNames = classNames(
         styles.dropdownContainer,
@@ -105,6 +103,24 @@ const Dropdown: FC<DropdownProps> = ({ controller, justification, children }) =>
         setMaxHeight(`calc(100vh - ${dropdownRect.top}px - (var(--grid-unit) * 3px))`);
     }, [rect, isOpen]);
 
+    const handleClick = (e) => {
+        if (dropdownRef.current.contains(e.target)) {
+            return;
+        }
+        close();
+    };
+
+    useEffect(() => {
+        if (isOpen) {
+            document.addEventListener('click', handleClick);
+        } else {
+            document.removeEventListener('click', handleClick);
+        }
+
+        return () => {
+            document.removeEventListener('click', handleClick);
+        };
+    }, [isOpen]);
     return (
         <>
             {node}

--- a/src/components/general/Scrim/index.tsx
+++ b/src/components/general/Scrim/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import styles from './styles.less';
-import { FC, ReactNode, MouseEvent } from 'react';
+import { FC, ReactNode, MouseEvent, useState, useRef } from 'react';
 
 type ScrimProps = {
     children: ReactNode;
@@ -9,12 +9,30 @@ type ScrimProps = {
 };
 
 const Scrim: FC<ScrimProps> = ({ children, show, onClick }) => {
+    const [mouseDownTarget, setMouseDownTarget] = useState({});
+    const [mouseUpTarget, setMouseUpTarget] = useState({});
+
+    const ref = useRef<HTMLDivElement | null>(null);
     const scrimClassNames = classNames(styles.scrim, {
         [styles.show]: show,
     });
 
+    const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+        if (
+            (mouseUpTarget as Node).isEqualNode(mouseDownTarget as Node) &&
+            (ref.current as Node).isEqualNode(e.target as Node)
+        ) {
+            onClick(e);
+        }
+    };
     return (
-        <div className={scrimClassNames} onClick={onClick}>
+        <div
+            ref={ref}
+            className={scrimClassNames}
+            onClick={(e) => handleClick(e)}
+            onMouseDown={(e) => setMouseDownTarget(e.target)}
+            onMouseUp={(e) => setMouseUpTarget(e.target)}
+        >
             {children}
         </div>
     );

--- a/src/components/general/SideSheet/Modal/index.tsx
+++ b/src/components/general/SideSheet/Modal/index.tsx
@@ -143,7 +143,6 @@ export default ({
                     <div
                         style={{ ...resizedSize }}
                         className={modalSideSheetClassNames}
-                        onClick={(e) => e.stopPropagation()}
                         onTransitionEnd={() => {
                             !isShowing && onClose && onClose();
                         }}


### PR DESCRIPTION
Fixes #1166 and #1165 

#1165 issue was because the side sheet component had a `stopPropagation()` and the click handler from `useClickOutsideOverlayPortal` wouldn't be added correctly. 
The logic inside Dropdown component now is to add an event listener every time the dropdown is open, and if you click somewhere outside of the div where dropdownRef is added, it will close. 

#1166 is fixed by storing the DOM nodes from mouseDown and mouseUp, and since `stopPropagation()` was removed, you'll also want to check if the user is clicking on the Scrim or the Sidesheet.