### PR TITLE
feat: allowing immediate past or future position

### DIFF
--- a/src/components/org/PositionPicker/components/AsideComponent.tsx
+++ b/src/components/org/PositionPicker/components/AsideComponent.tsx
@@ -1,27 +1,18 @@
 import { PersonPhoto } from '@equinor/fusion-components';
 import ItemComponentProps from './itemComponentProps';
 import { FC } from 'react';
+import { usePositionPickerContext } from '../positionPickerContext';
+import usePositionInstance from '../hooks/usePositionInstance';
 
 const AsideComponent: FC<ItemComponentProps> = ({ item }) => {
+    const { allowFuture, allowPast } = usePositionPickerContext();
+    const { instance } = usePositionInstance(item.position?.instances, allowFuture, allowPast);
+
     if (item.key === 'empty') {
         return null;
     }
 
-    const now = Date.now();
-    const activeInstance = item.position.instances.find(
-        (i) => now >= i.appliesFrom.getTime() && now <= i.appliesTo.getTime()
-    );
-
-    return (
-        <PersonPhoto
-            person={
-                activeInstance && activeInstance.assignedPerson
-                    ? activeInstance.assignedPerson
-                    : undefined
-            }
-            size="medium"
-        />
-    );
+    return <PersonPhoto person={instance?.assignedPerson ?? undefined} size="medium" />;
 };
 
 export default AsideComponent;

--- a/src/components/org/PositionPicker/components/ItemComponent.tsx
+++ b/src/components/org/PositionPicker/components/ItemComponent.tsx
@@ -1,16 +1,16 @@
 import ItemComponentProps from './itemComponentProps';
 import styles from '../styles.less';
 import { useMemo, FC } from 'react';
+import { usePositionPickerContext } from '../positionPickerContext';
+import usePositionInstance from '../hooks/usePositionInstance';
 
 const ItemComponent: FC<ItemComponentProps> = ({ item }) => {
+    const { allowFuture, allowPast } = usePositionPickerContext();
+    const { instance } = usePositionInstance(item.position?.instances, allowFuture, allowPast);
+
     if (item.key === 'empty') {
         return <div>{item.title}</div>;
     }
-
-    const now = Date.now();
-    const activeInstance = item.position.instances.find(
-        (i) => now >= i.appliesFrom.getTime() && now <= i.appliesTo.getTime()
-    );
 
     const positionName = useMemo(() => {
         if (!item.position.externalId) {
@@ -24,9 +24,7 @@ const ItemComponent: FC<ItemComponentProps> = ({ item }) => {
         <div className={styles.cardContainer}>
             <div className={styles.positionName}>{positionName}</div>
             <div className={styles.assignedPersonName}>
-                {activeInstance && activeInstance.assignedPerson
-                    ? activeInstance.assignedPerson.name
-                    : 'TNB'}
+                {instance?.assignedPerson ? instance.assignedPerson.name : 'TNB'}
             </div>
         </div>
     );

--- a/src/components/org/PositionPicker/hooks/usePositionInstance.ts
+++ b/src/components/org/PositionPicker/hooks/usePositionInstance.ts
@@ -1,0 +1,39 @@
+import { PositionInstance } from '@equinor/fusion';
+import { isAfter, isBefore } from 'date-fns';
+import { useMemo } from 'react';
+
+export default (
+    instances: PositionInstance[] = [],
+    allowFuture: boolean,
+    allowPast: boolean
+): { instance: PositionInstance } => {
+    const now = Date.now();
+    const activeInstance = instances.find(
+        (i) => now >= i.appliesFrom.getTime() && now <= i.appliesTo.getTime()
+    );
+
+    /**
+     * Returns current active position instance if it exists. If not,
+     * the following conditions will be evaluated (in this order):
+     * - allowFuture is true; the closest future instance is returned
+     * - allowPast is true; the closest past instance is returned
+     */
+    const instance = useMemo(() => {
+        if (activeInstance) return activeInstance;
+
+        const instancesSortedByFrom = [...instances].sort(
+            (a, b) => a.appliesFrom.getTime() - b.appliesFrom.getTime()
+        );
+        const futureInstance = instancesSortedByFrom.filter((x) => isAfter(x.appliesFrom, now))[0];
+
+        const instancesSortedByTo = [...instances].sort(
+            (a, b) => b.appliesTo.getTime() - a.appliesTo.getTime()
+        );
+        const pastInstance = instancesSortedByTo.filter((x) => isBefore(x.appliesTo, now))[0];
+
+        if (allowFuture && futureInstance) return futureInstance;
+        if (allowPast && pastInstance) return pastInstance;
+    }, [instances, activeInstance]);
+
+    return { instance };
+};

--- a/src/components/org/PositionPicker/index.tsx
+++ b/src/components/org/PositionPicker/index.tsx
@@ -8,6 +8,7 @@ import {
     singlePositionToDropdownOption,
     positionsToDropdownOption,
 } from './positionToDropdownSection';
+import { PositionPickerContex } from './positionPickerContext';
 
 type PositionPickerProps = {
     initialPosition?: Position;
@@ -17,6 +18,8 @@ type PositionPickerProps = {
     selectedPosition: Position | null;
     label?: string;
     placeholder?: string;
+    allowFuture?: boolean;
+    allowPast?: boolean;
 };
 
 const PositionPicker = ({
@@ -27,12 +30,16 @@ const PositionPicker = ({
     contractId,
     label,
     placeholder,
+    allowFuture,
+    allowPast,
 }: PositionPickerProps) => {
     const [options, setOptions] = useState<SearchableDropdownOption[]>([]);
     const [error, isFetching, filteredPositions, search] = usePositionQuery(
         selectedPosition,
         projectId,
-        contractId
+        contractId,
+        allowFuture,
+        allowPast
     );
     const [searchQuery, setSearchQuery] = useState('');
 
@@ -62,15 +69,17 @@ const PositionPicker = ({
     );
 
     return (
-        <SearchableDropdown
-            options={options}
-            onSelect={handleSelect}
-            itemComponent={ItemComponent}
-            asideComponent={AsideComponent}
-            onSearchAsync={setSearchQuery}
-            label={label}
-            placeholder={placeholder || 'Select position'}
-        />
+        <PositionPickerContex.Provider value={{ allowFuture: allowFuture, allowPast: allowPast }}>
+            <SearchableDropdown
+                options={options}
+                onSelect={handleSelect}
+                itemComponent={ItemComponent}
+                asideComponent={AsideComponent}
+                onSearchAsync={setSearchQuery}
+                label={label}
+                placeholder={placeholder || 'Select position'}
+            />
+        </PositionPickerContex.Provider>
     );
 };
 

--- a/src/components/org/PositionPicker/positionPickerContext.ts
+++ b/src/components/org/PositionPicker/positionPickerContext.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+type PositionPickerContex = {
+    allowFuture: boolean;
+    allowPast: boolean;
+};
+
+export const PositionPickerContex = createContext<PositionPickerContex>({
+    allowFuture: false,
+    allowPast: false,
+});
+
+export const usePositionPickerContext = () => useContext(PositionPickerContex);


### PR DESCRIPTION
Changes made to allow for task manager position picker in Org Admin to show the position with closest future instance.assignedPerson (if no active instance).  
https://statoil-proview.visualstudio.com/Fusion/_backlogs/backlog/Fusion%20Team/Epics/?showParents=true&workitem=21390