### PR TITLE
fix: Position timeline disabled pointer events

### DIFF
--- a/src/components/org/PositionTimeline/components/Split/index.tsx
+++ b/src/components/org/PositionTimeline/components/Split/index.tsx
@@ -46,7 +46,7 @@ export const Split: FC<SplitProps> = ({ id, rotationId, split }) => {
             className={clsx(styles.container, {
                 [styles.highlighted]: [...selected, ...highlighted].includes(id),
                 [styles.disabled]: isDisabled,
-                [styles.clickable]: mode !== 'slider',
+                [styles.clickable]: mode !== 'slider' && !isDisabled,
             })}
             style={{
                 left: `${computePosition(split.appliesFrom.getTime(), 'start')}%`,

--- a/src/components/org/PositionTimeline/components/Split/index.tsx
+++ b/src/components/org/PositionTimeline/components/Split/index.tsx
@@ -31,6 +31,9 @@ export const Split: FC<SplitProps> = ({ id, rotationId, split }) => {
     const isSelected = selected.includes(id);
 
     const handleClick = (e) => {
+        if (isDisabled) {
+            return;
+        }
         e.stopPropagation();
         if (mode === 'slider') return;
         dispatch(actions.selectSplit(id));

--- a/src/components/org/PositionTimeline/components/Split/styles.ts
+++ b/src/components/org/PositionTimeline/components/Split/styles.ts
@@ -43,6 +43,9 @@ export const useStyles = makeStyles((theme) =>
             )} !important`,
             cursor: 'default',
             opacity: 0.7,
+            '&:hover': {
+                cursor: 'default',
+            },
         },
         clickable: {
             '&:hover': {

--- a/src/components/org/PositionTimeline/components/Split/styles.ts
+++ b/src/components/org/PositionTimeline/components/Split/styles.ts
@@ -43,7 +43,6 @@ export const useStyles = makeStyles((theme) =>
             )} !important`,
             cursor: 'default',
             opacity: 0.7,
-            pointerEvents: 'none',
         },
         clickable: {
             '&:hover': {

--- a/src/components/org/PositionTimeline/components/Split/styles.ts
+++ b/src/components/org/PositionTimeline/components/Split/styles.ts
@@ -41,7 +41,7 @@ export const useStyles = makeStyles((theme) =>
             borderColor: `${theme.colors.interactive.disabled__border.getVariable(
                 'color'
             )} !important`,
-            cursor: 'auto',
+            cursor: 'default',
             opacity: 0.7,
             pointerEvents: 'none',
         },

--- a/src/components/org/PositionTimeline/index.tsx
+++ b/src/components/org/PositionTimeline/index.tsx
@@ -1,10 +1,5 @@
 import { FC } from 'react';
-import {
-    SelectMode,
-    TimelineSplit,
-    TimelinePosition,
-    TimelineSlotProps,
-} from './model';
+import { SelectMode, TimelineSplit, TimelinePosition, TimelineSlotProps } from './model';
 import RotationSequence from './components/RotationSequence';
 import TimelineProvider from './TimelineProvider';
 import { PersonSlot } from './components/PersonSlot';

--- a/src/components/org/PositionTimeline/model.ts
+++ b/src/components/org/PositionTimeline/model.ts
@@ -13,9 +13,9 @@ export type TimelineSplit = {
     type: 'Normal' | 'Rotation';
     location: {
         id: string;
-        name?: string;
-        country?: string;
-        code?: string;
+        name: string;
+        country: string;
+        code: string;
     } | null;
     assignedPerson: {
         azureUniqueId?: string;

--- a/src/components/org/PositionTimeline/model.ts
+++ b/src/components/org/PositionTimeline/model.ts
@@ -13,10 +13,10 @@ export type TimelineSplit = {
     type: 'Normal' | 'Rotation';
     location: {
         id: string;
-        name: string;
-        country: string;
-        code: string;
-    } |  null;
+        name?: string;
+        country?: string;
+        code?: string;
+    } | null;
     assignedPerson: {
         azureUniqueId?: string;
         mail?: string | null;
@@ -52,7 +52,7 @@ export type TemporalSplitGroups = Record<string, TimelineSplit[]>;
 export type RotationColumn = {
     split: TimelineSplit;
     linked: TimelineSplit[];
-}
+};
 
 export type RotationColumns = Record<string, RotationColumn>;
 
@@ -60,7 +60,7 @@ export type TimelineSlotProps = {
     split: TimelineSplit;
     position: TimelinePosition;
     isSelected: boolean;
-}
+};
 
 export type SelectMode = 'single' | 'multi' | 'slider';
 


### PR DESCRIPTION
Allow for pointer events for disabled timeline splits. This is to show the tool tip even though the split is disabled