### PR TITLE
Power BI ReportInfo CSS Missing

### DIFF
--- a/src/components/data/PowerBI/ReportInfo/PowerBIReportInfo.tsx
+++ b/src/components/data/PowerBI/ReportInfo/PowerBIReportInfo.tsx
@@ -31,6 +31,11 @@ export const PowerBIReportInfo: FC<Props> = ({
     }, [id, clients]);
     const initialized = useSelector(store, 'initialized');
 
+    const restrictedAccessContainer = useMemo(
+        () => classNames(useElevationClassName(3), styles.restrictedAccessContainer),
+        []
+    );
+
     useEffect(() => {
         return store.initialize();
     }, [store]);
@@ -43,10 +48,10 @@ export const PowerBIReportInfo: FC<Props> = ({
     const personId = report?.ownedBy?.azureUniqueId;
 
     return (
-        <div className={styles.reportErroMessage}>
+        <div className={styles.pbiErrorMessage}>
             <div className={styles.container}>
                 <h2 className={styles.header}>{header}</h2>
-                <div className={classNames(useElevationClassName(3), styles.restrictedAccessContainer)}>
+                <div className={restrictedAccessContainer}>
                     <h2>{subHeader}</h2>
                     {accessDescription && <MarkdownViewer markdown={accessDescription} />}
                     <div className={styles.reportInfoContainer}>

--- a/src/components/data/PowerBI/ReportInfo/styles.less
+++ b/src/components/data/PowerBI/ReportInfo/styles.less
@@ -1,85 +1,82 @@
-.reportErroMessage{
-    display:flex;
-  justify-content: center;
-  height: 100%;
-  width: 100%;  
-  
-  .container {
-    display:flex;
-    flex-direction: column;
-    align-items: center;
-    flex: 0 0 100%;
-    min-width: calc(var(--grid-unit) * 65px );
-    max-width: calc(var(--grid-unit) * 100px );
+.pbiErrorMessage {
+    display: flex;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
 
-    .header {
-      color : var(--color-orange);
-      margin-bottom: calc(var(--grid-unit) * 5px);
-    }
-
-    .restrictedAccessContainer {
-      box-sizing: border-box;
-      padding:calc(var(--grid-unit) * 3px);
-      width: 100%;  
-      border-radius: 4px;
-      background-color: var(--color-white);
-          
-      .reportInfoContainer {
-        display:grid;
-        grid-template-columns: 3fr 1fr;
-        grid-gap: calc(var(--grid-unit) * 6px);
-        
-        h5 {
-          margin-bottom: calc(var(--grid-unit) * 2px )
-        }
-        
-      }
-      
-      .serviceNowContainer {
-        display:flex;
+    .container {
+        display: flex;
         flex-direction: column;
         align-items: center;
-        
-        
-        
-        h4 {
-          padding-bottom:calc(var(--grid-unit) * 3px);
-        }
-      }
-    }
-    .userIdentityContainer {
-      width: 100%;
-      box-sizing: border-box;
-      padding:calc(var(--grid-unit) * 3px);
-      color: var(--color-black-alt2);
+        flex: 0 0 100%;
+        min-width: calc(var(--grid-unit) * 65px);
+        max-width: calc(var(--grid-unit) * 100px);
 
-      h4 { 
-        font-weight: 500;
-      }
-      
-      .info {
-        display:flex;
-        flex-direction: row;
-        
-        div {
-          padding: calc(var(--grid-unit) * 1px);
-          min-height: calc(var(--grid-unit) * 2px) ;
-        }
-        
-        .labels {
-          font-weight: 500;
+        .header {
+            color: var(--color-orange);
+            margin-bottom: calc(var(--grid-unit) * 5px);
         }
 
-        .text {
-          font-weight: bold;
-        }
-      }
-    }
+        .restrictedAccessContainer {
+            box-sizing: border-box;
+            padding: calc(var(--grid-unit) * 3px);
+            width: 100%;
+            border-radius: 4px;
+            background-color: var(--color-white);
 
-    .accessControlContainer {
-      background-color: var(--color-white);
-      width: 100%;
-      margin:calc(var(--grid-unit) * 2px) ;
+            .reportInfoContainer {
+                display: grid;
+                grid-template-columns: 3fr 1fr;
+                grid-gap: calc(var(--grid-unit) * 6px);
+
+                h5 {
+                    margin-bottom: calc(var(--grid-unit) * 2px);
+                }
+            }
+
+            .serviceNowContainer {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+
+                h4 {
+                    padding-bottom: calc(var(--grid-unit) * 3px);
+                }
+            }
+        }
+        .userIdentityContainer {
+            width: 100%;
+            box-sizing: border-box;
+            padding: calc(var(--grid-unit) * 3px);
+            color: var(--color-black-alt2);
+
+            h4 {
+                font-weight: 500;
+            }
+
+            .info {
+                display: flex;
+                flex-direction: row;
+
+                div {
+                    padding: calc(var(--grid-unit) * 1px);
+                    min-height: calc(var(--grid-unit) * 2px);
+                }
+
+                .labels {
+                    font-weight: 500;
+                }
+
+                .text {
+                    font-weight: bold;
+                }
+            }
+        }
+
+        .accessControlContainer {
+            background-color: var(--color-white);
+            width: 100%;
+            margin: calc(var(--grid-unit) * 2px);
+        }
     }
-  }
 }


### PR DESCRIPTION
the reportInfo componeents css does not show when in use in apps.
Tested this locally, but the problem was not very consistent, and kinda fixed itself without any changes.
In an attempt to fix this, Ive changed the parent className for reportInfo so its unique, in terms of the old PBI component. As we have had problems with this in the past.
Also moved the useElevataionClassname outside the render part of reportInfo.