### PR TITLE
Power BI Info css fix

### DIFF
--- a/src/components/data/PowerBI/ReportInfo/PowerBIReportInfo.tsx
+++ b/src/components/data/PowerBI/ReportInfo/PowerBIReportInfo.tsx
@@ -12,7 +12,7 @@ import { PowerBIInfoUserIdentity } from './PowerBIUserIdentity';
 import { PowerBIInfoRequirements } from './PowerBIRequirements';
 
 import classNames from 'classnames';
-import * as styles from './styles.less';
+import styles from './styles.less';
 
 type Props = {
     id: string;

--- a/src/components/data/PowerBI/ReportInfo/PowerBIRequirements.tsx
+++ b/src/components/data/PowerBI/ReportInfo/PowerBIRequirements.tsx
@@ -6,7 +6,7 @@ import { Accordion, AccordionItem, MarkdownViewer } from '@equinor/fusion-compon
 
 import { Store } from './store/store';
 
-import * as styles from './styles.less';
+import styles from './styles.less';
 
 export const PowerBIInfoRequirements: FC<{ store: Store }> = ({ store }) => {
     const requirements = useSelector(store, 'requirements');
@@ -14,7 +14,11 @@ export const PowerBIInfoRequirements: FC<{ store: Store }> = ({ store }) => {
     return requirements ? (
         <div className={styles.accessControlContainer}>
             <Accordion>
-                <AccordionItem label={'Access control description'} isOpen={open} onChange={() => setOpen(!open)}>
+                <AccordionItem
+                    label={'Access control description'}
+                    isOpen={open}
+                    onChange={() => setOpen(!open)}
+                >
                     <MarkdownViewer markdown={requirements} />
                 </AccordionItem>
             </Accordion>

--- a/src/components/data/PowerBI/ReportInfo/PowerBIUserIdentity.tsx
+++ b/src/components/data/PowerBI/ReportInfo/PowerBIUserIdentity.tsx
@@ -2,13 +2,15 @@ import { FC } from 'react';
 
 import { useCurrentUser } from '@equinor/fusion';
 
-import * as styles from './styles.less';
+import styles from './styles.less';
 
 type Props = { header?: string };
 
 export const PowerBIInfoUserIdentity: FC<Props> = (props) => {
     const user = useCurrentUser();
-    const header = props.header || 'Your identity does not meet this reports access requirements, your identity is:';
+    const header =
+        props.header ||
+        'Your identity does not meet this reports access requirements, your identity is:';
     return (
         <div className={styles.userIdentityContainer}>
             <h4>{header}</h4>

--- a/src/components/data/PowerBI/index.ts
+++ b/src/components/data/PowerBI/index.ts
@@ -1,11 +1,11 @@
 export { PowerBI } from './Report';
 export { PowerBIReportInfo } from './ReportInfo';
 
-export { 
-  IBasicFilter, 
-  IAdvancedFilter, 
-  IBasicFilterWithKeys,
-  IRelativeDateFilter,
-  ITupleFilter,
-  ReportLevelFilters
+export {
+    IBasicFilter,
+    IAdvancedFilter,
+    IBasicFilterWithKeys,
+    IRelativeDateFilter,
+    ITupleFilter,
+    ReportLevelFilters,
 } from 'powerbi-models';


### PR DESCRIPTION
Styles imported in the ReportInfo in a "fusion app" kind of way, but in components they are not usually imported that way.

Changed import to be consistent with other styles import.