### PR TITLE
Fix Person Photo squishing issue

### DIFF
--- a/src/components/people/PersonPhoto/index.tsx
+++ b/src/components/people/PersonPhoto/index.tsx
@@ -118,22 +118,20 @@ export default ({
             className={photoClassNames}
             style={imageStyle}
         >
-            <div>
-                <div className={popoverClassNames}>
-                    {(imageError !== null || additionalPersons.length > 0 || !id) && (
-                        <FallbackImage size={size} rotation={additionalPersons.length > 0} />
-                    )}
-                    {personDetails && additionalPersons.length === 0 && (
-                        <AccountTypeBadge currentPerson={personDetails} size={size} />
-                    )}
-                    {additionalPersons.length > 0 && (
-                        <RotationBadge
-                            numberOfPersons={additionalPersons.length + 1}
-                            size={size}
-                            hideTooltip={hideTooltip}
-                        />
-                    )}
-                </div>
+            <div className={popoverClassNames}>
+                {(imageError !== null || additionalPersons.length > 0 || !id) && (
+                    <FallbackImage size={size} rotation={additionalPersons.length > 0} />
+                )}
+                {personDetails && additionalPersons.length === 0 && (
+                    <AccountTypeBadge currentPerson={personDetails} size={size} />
+                )}
+                {additionalPersons.length > 0 && (
+                    <RotationBadge
+                        numberOfPersons={additionalPersons.length + 1}
+                        size={size}
+                        hideTooltip={hideTooltip}
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/components/people/PersonPhoto/styles.less
+++ b/src/components/people/PersonPhoto/styles.less
@@ -56,6 +56,10 @@
         }
     }
 
+    .popoverDetails {
+        width: inherit;
+    }
+
     .iconContainer {
         border-radius: 50%;
         position: absolute;


### PR DESCRIPTION
When background-image was used, the div had 0 in width which caused squishing of image when a max-width was set on the person photo component.
Solved by removing redundant div + make div inherit width from parent