### PR TITLE
Navigation Drawer Fix - When collapsed, external link navigation did not work 

### DIFF
--- a/src/components/general/NavigationDrawer/__stories__/NavigationDrawer.stories.tsx
+++ b/src/components/general/NavigationDrawer/__stories__/NavigationDrawer.stories.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import withFusionStory from '../../../../../.storybook/withFusionStory';
 import NavigationDrawer, { NavigationStructure } from '../index';
-import { ErrorIcon, WarningIcon, useAnchor } from '@equinor/fusion-components';
+import { ErrorIcon, WarningIcon } from '@equinor/fusion-components';
+import { OpenInNewIcon } from '../../../icons/components/action';
 import Chip from '../../Chip';
 
 const getNavStructure = (): NavigationStructure[] => {
@@ -117,6 +118,14 @@ const getNavStructure = (): NavigationStructure[] => {
             title: 'Grouping4',
             icon: <ErrorIcon outline />,
             aside: <ErrorIcon outline />,
+        },
+        {
+            id: 'grouping5',
+            type: 'grouping',
+            title: 'Open in new',
+            icon: <OpenInNewIcon />,
+            aside: <OpenInNewIcon />,
+            href: 'https://fusion.equinor.com/'
         },
     ]
 }

--- a/src/components/general/NavigationDrawer/components/Grouping.tsx
+++ b/src/components/general/NavigationDrawer/components/Grouping.tsx
@@ -57,7 +57,7 @@ const Grouping: FC<NavigationComponentProps> = ({ navigationItem, onChange, isCo
                 <a
                     className={styles.linkContainer}
                     onClick={change}
-                    href={!isDisabled && !isCollapsed ? href : undefined}
+                    href={!isDisabled && href?.length ? href : undefined}
                 >
                     <div className={iconClasses}>{icon}</div>
                     <span className={styles.linkText} ref={textRef}>


### PR DESCRIPTION
https://statoil-proview.visualstudio.com/Fusion/_backlogs/backlog/Operations%20and%20Improvements/Stories/?showParents=true&workitem=22859

External app navigation did not work when nevigation drawer was collapsed. Removed !isCollapsed condition for rendering href.
Also checking for href length, to avoid showing link preview in bottom corner when hovering over menu items with no actual link when menu is not collapsed.