### PR TITLE
PowerBI -  use new version of bookmarks manager

### DIFF
--- a/src/components/data/PowerBI/Report/PowerBI.tsx
+++ b/src/components/data/PowerBI/Report/PowerBI.tsx
@@ -30,8 +30,9 @@ export const PowerBI: FunctionComponent<PowerBIProps> = ({
         <PowerBIBookmark hasContext={hasContext} />
         <context.Consumer>
             {(value) => {
-                if (contextRef?.current && contextRef?.current !== value)
+                if (contextRef && contextRef?.current !== value) {
                     contextRef.current = value || undefined;
+                }
                 return null;
             }}
         </context.Consumer>

--- a/src/components/data/PowerBI/Report/components/PowerBIBookmark.tsx
+++ b/src/components/data/PowerBI/Report/components/PowerBIBookmark.tsx
@@ -4,7 +4,7 @@ import { Report } from 'powerbi-client';
 import { filter, first } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { useSelector } from '@equinor/fusion';
-import { AppSettingsManager } from '@equinor/fusion-components';
+import { BookmarksManager } from '@equinor/fusion-components';
 
 type Props = {
     hasContext: boolean;
@@ -53,9 +53,11 @@ export const PowerBIBookmark: FunctionComponent<Props> = ({ hasContext }: Props)
     };
 
     return (
-        <AppSettingsManager
-            captureAppSetting={captureBookmark}
-            applyAppSetting={applyBookmark}
+        <BookmarksManager
+            capturePayload={captureBookmark}
+            applyBookmark={(bookmark, awaitForContextSwitch) =>
+                applyBookmark(bookmark.payload, awaitForContextSwitch)
+            }
             hasContext={hasContext}
             anchorId="pbi-bookmarks-btn"
             name="Power BI bookmarks"

--- a/src/components/data/PowerBI/Report/components/PowerBIBookmark.tsx
+++ b/src/components/data/PowerBI/Report/components/PowerBIBookmark.tsx
@@ -29,7 +29,7 @@ export const PowerBIBookmark: FunctionComponent<Props> = ({ hasContext }: Props)
      */
     useSelector(store, 'status');
 
-    const report = useMemo(() => component?.current as Report, [component]);
+    const report = component?.current as Report;
 
     const captureBookmark = async () => {
         if (!report) return '';

--- a/src/components/data/PowerBI/Report/components/PowerBIReportProvider.tsx
+++ b/src/components/data/PowerBI/Report/components/PowerBIReportProvider.tsx
@@ -2,18 +2,27 @@ import { useEffect, PropsWithChildren, FunctionComponent, useRef, useMemo } from
 
 import { useCurrentContext, useTelemetryLogger, useApiClients } from '@equinor/fusion';
 
-import { context, PowerBIEmbedComponent, PowerBIEmbedEventEntry, PowerBIReportContext } from '../context';
+import {
+    context,
+    PowerBIEmbedComponent,
+    PowerBIEmbedEventEntry,
+    PowerBIReportContext,
+} from '../context';
 import { Subject, Subscription } from 'rxjs';
 import PowerBITelemetryObserver from '../telemetry/observer';
 import { createStore, actions } from '../store';
-import { distinctUntilKeyChanged, filter, tap } from 'rxjs/operators';
+import { distinctUntilKeyChanged, filter } from 'rxjs/operators';
 import { isActionOf } from 'typesafe-actions';
 
 type Props = PropsWithChildren<{ id: string; hasContext: boolean }>;
 
 const { Provider } = context;
 
-export const PowerBIReportProvider: FunctionComponent<Props> = ({ children, id, hasContext }: Props) => {
+export const PowerBIReportProvider: FunctionComponent<Props> = ({
+    children,
+    id,
+    hasContext,
+}: Props) => {
     const clients = useApiClients();
     const store = useMemo(() => createStore(id, clients), [id, clients]);
 

--- a/src/components/data/PowerBI/Report/components/view/PowerBIReportView.tsx
+++ b/src/components/data/PowerBI/Report/components/view/PowerBIReportView.tsx
@@ -1,7 +1,5 @@
-import { useContext, useEffect, FC, useCallback, useMemo } from 'react';
-
+import { useContext, useEffect, FC, useMemo } from 'react';
 import { PowerBIEmbed, EventHandler } from 'powerbi-client-react';
-
 import { context, PowerBIEmbedEvents } from '../../context';
 import { IEmbedConfiguration, service as PowerBIServices, factories } from 'powerbi-client';
 import useConfig from './useConfig';
@@ -47,10 +45,9 @@ export const PowerBIReportView: FC<PowerBIComponentProps> = ({ config }: PowerBI
         [event$]
     );
 
-    const getEmbeddedComponent = useCallback(
-        (value) => (component?.current ? (component.current = value) : null),
-        [component]
-    );
+    const getEmbeddedComponent = (value) => {
+        component.current = value;
+    };
 
     usePowerBIFilters(event$, config?.filters);
 


### PR DESCRIPTION
Using the new version of Bookmarks Manager component. Related to issue #1330 
Needs to be tested with how the new PowerBI component works (edit: tested it, works fine)

Couple of things:
* AppSettingsManager is deprecated, use BookmarksManager instead
* The `component` ref initialized in the PowerBI provider would always be undefined. It's fixed now by changing the `getEmbeddedComponent` logic. 
* The `contextRef` prop passed to the PowerBI component  would also not be assigned the correct value.
* Using refs in dependency arrays has no effect, so removed them