### PR TITLE
chore: deprecate appsettingsmanager component

### DIFF
--- a/src/components/general/AppSettingsManager/index.tsx
+++ b/src/components/general/AppSettingsManager/index.tsx
@@ -16,7 +16,9 @@ export type AppSettingsManagerProps<T> = {
     anchorId: string;
     hasContext?: boolean;
 };
-
+/**
+ * @deprecated Use the new BookmarksManager component instead.
+ */
 function AppSettingsManager<T>(props: AppSettingsManagerProps<T>) {
     const [isSideSheetOpen, setIsSideSheetOpen] = useState<boolean>(false);
     const openSideSheet = useCallback(() => setIsSideSheetOpen(true), []);


### PR DESCRIPTION
AppSettingsManager component is deprecated, use BookmarksManager instead. BookmarksManager also uses a different database than the deprecated component, so using it will require us to do more database migrations in the future when switching to BookmarksManager.