### PR TITLE
fix: Sidesheet - Remove border from collapse button 

### DIFF
--- a/src/components/general/SideSheet/Standard/styles.less
+++ b/src/components/general/SideSheet/Standard/styles.less
@@ -83,7 +83,6 @@
     .collapseButtonContainer {
         width: .grid-unit(6px) [];
         height: .grid-unit(6px) [];
-        border-bottom: 1px solid var(--color-black-alt4);
         display: flex;
         justify-content: center;
         align-items: center;


### PR DESCRIPTION
Remove border-bottom from .collpaseButtonContainer in the sidesheet component.

This added a border under the collapse button when using resizable sidesheet.
But the header container in general does not have an underline. Making this look like a short line sticking out into nothing.