### PR TITLE
Hotfix/powerbi checkcontextaccess

### DIFF
--- a/src/components/data/PowerBI/Report/store/actions/access.ts
+++ b/src/components/data/PowerBI/Report/store/actions/access.ts
@@ -5,16 +5,20 @@ import { HttpClientRequestFailedError } from '@equinor/fusion/lib/http/HttpClien
 import { ActionError } from '@equinor/fusion/lib/epic';
 
 export type AccessActions = ActionType<typeof actions>;
+export type AccessRequest = {
+    reportId: string;
+    silent?: boolean;
+};
 
 export const fetchAccessToken = createAsyncAction(
-  '@PBI/FETCH_REPORT_TOKEN_REQUEST',
-  '@PBI/FETCH_REPORT_TOKEN_SUCCESS',
-  '@PBI/FETCH_REPORT_TOKEN_FAILURE',
-  '@PBI/FETCH_REPORT_TOKEN_CANCEL'
-)<string, AccessToken, ActionError<HttpClientRequestFailedError<any>>, string | void>();
+    '@PBI/FETCH_REPORT_TOKEN_REQUEST',
+    '@PBI/FETCH_REPORT_TOKEN_SUCCESS',
+    '@PBI/FETCH_REPORT_TOKEN_FAILURE',
+    '@PBI/FETCH_REPORT_TOKEN_CANCEL'
+)<AccessRequest, AccessToken, ActionError<HttpClientRequestFailedError<any>>, string | void>();
 
 export const refreshAccessToken = createAction('@PBI/FETCH_REPORT_TOKEN_REFRESH')<void>();
 
-const actions = { fetchAccessToken, refreshAccessToken }
+const actions = { fetchAccessToken, refreshAccessToken };
 
 export default actions;

--- a/src/components/data/PowerBI/Report/store/actions/context.ts
+++ b/src/components/data/PowerBI/Report/store/actions/context.ts
@@ -5,18 +5,21 @@ import { ActionError } from '@equinor/fusion/lib/epic';
 
 export type ContextActions = ActionType<typeof actions>;
 
-export type CheckContextAccessRequest = { reportId: string, externalId: string, type: ContextTypes };
+export type CheckContextAccessRequest = {
+    reportId: string;
+    externalId: string;
+    type: ContextTypes;
+    silent?: boolean;
+};
 
 export const checkContextAccess = createAsyncAction(
-  '@PBI/CHECK_CONTEXT_ACCESS_REQUEST',
-  '@PBI/CHECK_CONTEXT_ACCESS_SUCCESS',
-  '@PBI/CHECK_CONTEXT_ACCESS_FAILURE',
-  '@PBI/CHECK_CONTEXT_ACCESS_CANCEL'
+    '@PBI/CHECK_CONTEXT_ACCESS_REQUEST',
+    '@PBI/CHECK_CONTEXT_ACCESS_SUCCESS',
+    '@PBI/CHECK_CONTEXT_ACCESS_FAILURE',
+    '@PBI/CHECK_CONTEXT_ACCESS_CANCEL'
 )<CheckContextAccessRequest, void, ActionError<HttpClientRequestFailedError<any>>, string | void>();
 
-export const setContextAccess = createAction(
-  '@PBI/SET_CONTEXT_ACCESS'
-)<boolean>();
+export const setContextAccess = createAction('@PBI/SET_CONTEXT_ACCESS')<boolean>();
 
 const actions = { checkContextAccess, setContextAccess };
 

--- a/src/components/data/PowerBI/Report/store/epics/access-token.ts
+++ b/src/components/data/PowerBI/Report/store/epics/access-token.ts
@@ -27,7 +27,7 @@ export const accessToken = <S extends { id: string }>(
     const request$ = action$.pipe(
         filter(isActionOf(actions.fetchAccessToken.request)),
         switchMap((action) =>
-            from(clients.report.getAccessToken(action.payload)).pipe(
+            from(clients.report.getAccessToken(action.payload.reportId)).pipe(
                 map((res) => actions.fetchAccessToken.success(res.data)),
                 catchError((error) => of(actions.fetchAccessToken.failure({ action, error }))),
                 takeUntil(action$.pipe(filter(isActionOf(actions.fetchAccessToken.cancel))))
@@ -48,7 +48,9 @@ export const accessToken = <S extends { id: string }>(
     );
 
     const refresh$ = acquired$.pipe(
-        switchMap(() => of(actions.fetchAccessToken.request(state$.value.id)))
+        switchMap(() =>
+            of(actions.fetchAccessToken.request({ reportId: state$.value.id, silent: true }))
+        )
     );
 
     return merge(request$, acquired$, refresh$);

--- a/src/components/data/PowerBI/Report/store/epics/access-token.ts
+++ b/src/components/data/PowerBI/Report/store/epics/access-token.ts
@@ -19,42 +19,39 @@ const refreshOffset = 60000;
  * When token is successfully fetched, a refresh will be scehduled
  * Also handles request for refresh (uses store id) and dispatches request for new token
  */
-export const accessToken = <S extends {id:string}>(
-  action$: Observable<ActionType<typeof actions>>,
-  state$: StatefulObserver<S>,
-  { clients }: Dependencies
-) =>
-  {
+export const accessToken = <S extends { id: string }>(
+    action$: Observable<ActionType<typeof actions>>,
+    state$: StatefulObserver<S>,
+    { clients }: Dependencies
+) => {
     const request$ = action$.pipe(
-      filter(isActionOf(actions.fetchAccessToken.request)),
-      switchMap(action => from(clients.report.getAccessToken(action.payload))
-        .pipe(
-          map(res => actions.fetchAccessToken.success(res.data)),
-          catchError(error => of(actions.fetchAccessToken.failure({ action, error }))),
-          takeUntil(action$.pipe(
-            filter(isActionOf(actions.fetchAccessToken.cancel))
-          ))
+        filter(isActionOf(actions.fetchAccessToken.request)),
+        switchMap((action) =>
+            from(clients.report.getAccessToken(action.payload)).pipe(
+                map((res) => actions.fetchAccessToken.success(res.data)),
+                catchError((error) => of(actions.fetchAccessToken.failure({ action, error }))),
+                takeUntil(action$.pipe(filter(isActionOf(actions.fetchAccessToken.cancel))))
+            )
         )
-      )
     );
 
     /**
      * when access token is acquired, schedule a refresh
      */
     const acquired$ = request$.pipe(
-      filter(isActionOf(actions.fetchAccessToken.success)),
-      switchMap(action => {
-        const { expirationUtc } = action.payload;
-        const expires = expirationUtc.getTime() - Date.now() - refreshOffset;
-        return of(actions.refreshAccessToken()).pipe(delay(expires));
-      })
+        filter(isActionOf(actions.fetchAccessToken.success)),
+        switchMap((action) => {
+            const { expirationUtc } = action.payload;
+            const expires = expirationUtc.getTime() - Date.now() - refreshOffset;
+            return of(actions.refreshAccessToken()).pipe(delay(expires));
+        })
     );
 
     const refresh$ = acquired$.pipe(
-      switchMap(() => of(actions.fetchAccessToken.request(state$.value.id)))
+        switchMap(() => of(actions.fetchAccessToken.request(state$.value.id)))
     );
 
     return merge(request$, acquired$, refresh$);
-  };
+};
 
 export default accessToken;

--- a/src/components/data/PowerBI/Report/store/epics/check-context-access.ts
+++ b/src/components/data/PowerBI/Report/store/epics/check-context-access.ts
@@ -6,35 +6,25 @@ import { isActionOf, ActionType } from 'typesafe-actions';
 import { ApiClients } from '@equinor/fusion';
 
 import { StatefulObserver } from '@equinor/fusion/lib/epic';
-import {
-  ContextActions,
-  checkContextAccess as checkContextAccessAction,
-} from '../actions/context';
+import { ContextActions, checkContextAccess as checkContextAccessAction } from '../actions/context';
 
 export type Dependencies = { clients: ApiClients };
 
 export const checkContextAccess = <S = any>(
-  action$: Observable<ContextActions>,
-  _: StatefulObserver<S>,
-  { clients }: Dependencies
+    action$: Observable<ContextActions>,
+    _: StatefulObserver<S>,
+    { clients }: Dependencies
 ) => {
-  
-  const fetch = (action: ActionType<typeof checkContextAccessAction.request>) => {
-    const { reportId, externalId, type } = action.payload;
-    return from(clients.report.checkContextAccess(reportId, externalId, type))
-      .pipe(
-        map(() => checkContextAccessAction.success()),
-        catchError(error => of(checkContextAccessAction.failure({ action, error }))),
-        takeUntil(action$.pipe(
-          filter(isActionOf(checkContextAccessAction.cancel))
-        ))
-      );
-  };
+    const fetch = (action: ActionType<typeof checkContextAccessAction.request>) => {
+        const { reportId, externalId, type } = action.payload;
+        return from(clients.report.checkContextAccess(reportId, externalId, type)).pipe(
+            map(() => checkContextAccessAction.success()),
+            catchError((error) => of(checkContextAccessAction.failure({ action, error }))),
+            takeUntil(action$.pipe(filter(isActionOf(checkContextAccessAction.cancel))))
+        );
+    };
 
-  return action$.pipe(
-    filter(isActionOf(checkContextAccessAction.request)),
-    switchMap(fetch)
-  );
+    return action$.pipe(filter(isActionOf(checkContextAccessAction.request)), switchMap(fetch));
 };
 
 export default checkContextAccess;

--- a/src/components/data/PowerBI/Report/store/epics/fetch-embed-info.ts
+++ b/src/components/data/PowerBI/Report/store/epics/fetch-embed-info.ts
@@ -1,5 +1,5 @@
 import { Observable, from, of } from 'rxjs';
-import { filter, switchMap, map, catchError, takeUntil, tap, first } from 'rxjs/operators';
+import { filter, switchMap, map, catchError, takeUntil } from 'rxjs/operators';
 
 import { isActionOf } from 'typesafe-actions';
 
@@ -7,29 +7,26 @@ import { ApiClients } from '@equinor/fusion';
 import { StatefulObserver } from '@equinor/fusion/lib/epic';
 
 import {
-  fetchEmbedInfo as fetchEmbedInfoAction,
-  FetchEmbedInfoAction
+    fetchEmbedInfo as fetchEmbedInfoAction,
+    FetchEmbedInfoAction,
 } from '../actions/embed-info';
 
 export type Dependencies = { clients: ApiClients };
 
 export const fecthEmbedInfo = <S = any>(
-  action$: Observable<FetchEmbedInfoAction>,
-  _: StatefulObserver<S>,
-  { clients }: Dependencies
+    action$: Observable<FetchEmbedInfoAction>,
+    _: StatefulObserver<S>,
+    { clients }: Dependencies
 ) =>
-  action$.pipe(
-    filter(isActionOf(fetchEmbedInfoAction.request)),
-    switchMap(action => from(clients.report.getEmbedInfo(action.payload))
-      .pipe(
-        map(res => fetchEmbedInfoAction.success(res.data)),
-        catchError(error => of(fetchEmbedInfoAction.failure({ action, error }))),
-        takeUntil(action$.pipe(
-          filter(isActionOf(fetchEmbedInfoAction.cancel))
-        ))
-      )
-    )
-  );
-
+    action$.pipe(
+        filter(isActionOf(fetchEmbedInfoAction.request)),
+        switchMap((action) =>
+            from(clients.report.getEmbedInfo(action.payload)).pipe(
+                map((res) => fetchEmbedInfoAction.success(res.data)),
+                catchError((error) => of(fetchEmbedInfoAction.failure({ action, error }))),
+                takeUntil(action$.pipe(filter(isActionOf(fetchEmbedInfoAction.cancel))))
+            )
+        )
+    );
 
 export default fecthEmbedInfo;

--- a/src/components/data/PowerBI/Report/store/epics/index.ts
+++ b/src/components/data/PowerBI/Report/store/epics/index.ts
@@ -1,6 +1,6 @@
-import {accessToken} from './access-token';
-import {checkContextAccess} from './check-context-access';
-import {fecthEmbedInfo} from './fetch-embed-info';
+import { accessToken } from './access-token';
+import { checkContextAccess } from './check-context-access';
+import { fecthEmbedInfo } from './fetch-embed-info';
 
 import { combineEpics } from '@equinor/fusion/lib/epic';
 
@@ -8,10 +8,10 @@ import { Actions } from '../actions';
 import { State } from '../state';
 
 export const epics = {
-  accessToken,
-  checkContextAccess,
-  fecthEmbedInfo,
-}
+    accessToken,
+    checkContextAccess,
+    fecthEmbedInfo,
+};
 
 export const epic = combineEpics<Actions, Actions, State>(...Object.values(epics));
 

--- a/src/components/data/PowerBI/Report/store/index.ts
+++ b/src/components/data/PowerBI/Report/store/index.ts
@@ -6,9 +6,9 @@ import { epic } from './epics';
 import { State } from './state';
 
 export const createStore = (id: string, clients: ApiClients): Store => {
-  const initial: State = { id, errors: [], status: [] };
-  return new Store(reducer, epic, initial, { clients });
-}
+    const initial: State = { id, errors: [], status: [] };
+    return new Store(reducer, epic, initial, { clients });
+};
 
 export { Store, State };
 export { Actions, actions } from './actions';

--- a/src/components/data/PowerBI/Report/store/reducers/context-access.ts
+++ b/src/components/data/PowerBI/Report/store/reducers/context-access.ts
@@ -9,7 +9,7 @@ export const checkAccessContextReducer = (initial: State) =>
         .handleAction(checkContextAccess.request, (state, action) => ({
             ...state,
             hasContextAccess: undefined,
-            status: [...state.status, Status.AccessCheck],
+            status: action.payload.silent ? state.status : [...state.status, Status.AccessCheck],
             errors: removeError(state, action),
         }))
         .handleAction(checkContextAccess.success, (state) => ({

--- a/src/components/data/PowerBI/Report/store/reducers/context-access.ts
+++ b/src/components/data/PowerBI/Report/store/reducers/context-access.ts
@@ -2,34 +2,32 @@ import { createReducer } from 'typesafe-actions';
 
 import { State, Status, removeError, removeStatus } from '../state';
 
-import {
-  ContextActions as Action,
-  checkContextAccess,
-  setContextAccess
-} from '../actions/context';
+import { ContextActions as Action, checkContextAccess, setContextAccess } from '../actions/context';
 
-export const checkAccessContextReducer = (initial: State) => createReducer<State, Action>(initial)
-  .handleAction(checkContextAccess.request, (state, action) => ({
-    ...state,
-    hasContextAccess: undefined,
-    status: [...state.status, Status.AccessCheck],
-    errors: removeError(state, action)
-  }))
-  .handleAction(checkContextAccess.success, (state) => ({
-    ...state,
-    hasContextAccess: true,
-    status: removeStatus(state, Status.AccessCheck),
-  }))
-  .handleAction(checkContextAccess.failure, (state, action) => ({
-    ...state,
-    hasContextAccess: false,
-    status: removeStatus(state, Status.AccessCheck),
-    errors: [...state.errors, action.payload],
-  }))
+export const checkAccessContextReducer = (initial: State) =>
+    createReducer<State, Action>(initial)
+        .handleAction(checkContextAccess.request, (state, action) => ({
+            ...state,
+            hasContextAccess: undefined,
+            status: [...state.status, Status.AccessCheck],
+            errors: removeError(state, action),
+        }))
+        .handleAction(checkContextAccess.success, (state) => ({
+            ...state,
+            hasContextAccess: true,
+            status: removeStatus(state, Status.AccessCheck),
+        }))
+        .handleAction(checkContextAccess.failure, (state, action) => ({
+            ...state,
+            hasContextAccess: false,
+            status: removeStatus(state, Status.AccessCheck),
+            errors: [...state.errors, action.payload],
+        }))
 
-  .handleAction(setContextAccess, (state, action) =>
-    state.hasContextAccess === action.payload ? state : { ...state, hasContextAccess: action.payload }
-  )
-
+        .handleAction(setContextAccess, (state, action) =>
+            state.hasContextAccess === action.payload
+                ? state
+                : { ...state, hasContextAccess: action.payload }
+        );
 
 export default checkAccessContextReducer;

--- a/src/components/data/PowerBI/Report/store/reducers/fetch-access-token.ts
+++ b/src/components/data/PowerBI/Report/store/reducers/fetch-access-token.ts
@@ -2,26 +2,26 @@ import { createReducer } from 'typesafe-actions';
 
 import { State, Status, removeError, removeStatus } from '../state';
 
-import {
-  AccessActions as Actions,
-  fetchAccessToken as actions
-} from '../actions/access';
+import { AccessActions as Actions, fetchAccessToken as actions } from '../actions/access';
 
-export const fetchAccessTokenReducer = (initial: State) => createReducer<State, Actions>(initial)
-  .handleAction(actions.request, (state, action) => ({
-    ...state,
-    status: [...state.status, Status.AcquiringAccessToken],
-    errors: removeError(state, action)
-  }))
-  .handleAction(actions.success, (state, action) => ({
-    ...state,
-    status: removeStatus(state, Status.AcquiringAccessToken),
-    token: action.payload,
-  }))
-  .handleAction(actions.failure, (state, action) => ({
-    ...state,
-    status: removeStatus(state, Status.AcquiringAccessToken),
-    errors: [...state.errors, action.payload],
-  }))
+export const fetchAccessTokenReducer = (initial: State) =>
+    createReducer<State, Actions>(initial)
+        .handleAction(actions.request, (state, action) => ({
+            ...state,
+            status: action.payload.silent
+                ? state.status
+                : [...state.status, Status.AcquiringAccessToken],
+            errors: removeError(state, action),
+        }))
+        .handleAction(actions.success, (state, action) => ({
+            ...state,
+            status: removeStatus(state, Status.AcquiringAccessToken),
+            token: action.payload,
+        }))
+        .handleAction(actions.failure, (state, action) => ({
+            ...state,
+            status: removeStatus(state, Status.AcquiringAccessToken),
+            errors: [...state.errors, action.payload],
+        }));
 
 export default fetchAccessTokenReducer;

--- a/src/components/data/PowerBI/Report/store/reducers/fetch-embed-info.ts
+++ b/src/components/data/PowerBI/Report/store/reducers/fetch-embed-info.ts
@@ -2,26 +2,24 @@ import { createReducer } from 'typesafe-actions';
 
 import { State, Status, removeStatus } from '../state';
 
-import {
-  FetchEmbedInfoAction as Actions,
-  fetchEmbedInfo as actions
-} from '../actions/embed-info';
+import { FetchEmbedInfoAction as Actions, fetchEmbedInfo as actions } from '../actions/embed-info';
 
-export const fetchEmbedInfoReducer = (initial: State) => createReducer<State, Actions>(initial)
-  .handleAction(actions.request, (_, action) => ({
-    id: action.payload,
-    status: [Status.LoadingEmbedInfo],
-    errors: []
-  }))
-  .handleAction(actions.success, (state, action) => ({
-    ...state,
-    status: removeStatus(state, Status.LoadingEmbedInfo),
-    embedInfo: action.payload.embedConfig,
-  }))
-  .handleAction(actions.failure, (state, action) => ({
-    ...state,
-    status: removeStatus(state, Status.LoadingEmbedInfo),
-    errors: [...state.errors, action.payload],
-  }));
+export const fetchEmbedInfoReducer = (initial: State) =>
+    createReducer<State, Actions>(initial)
+        .handleAction(actions.request, (_, action) => ({
+            id: action.payload,
+            status: [Status.LoadingEmbedInfo],
+            errors: [],
+        }))
+        .handleAction(actions.success, (state, action) => ({
+            ...state,
+            status: removeStatus(state, Status.LoadingEmbedInfo),
+            embedInfo: action.payload.embedConfig,
+        }))
+        .handleAction(actions.failure, (state, action) => ({
+            ...state,
+            status: removeStatus(state, Status.LoadingEmbedInfo),
+            errors: [...state.errors, action.payload],
+        }));
 
 export default fetchEmbedInfoReducer;

--- a/src/components/data/PowerBI/Report/store/reducers/index.ts
+++ b/src/components/data/PowerBI/Report/store/reducers/index.ts
@@ -6,11 +6,11 @@ import { checkAccessContextReducer } from './context-access';
 import { fetchAccessTokenReducer } from './fetch-access-token';
 import { fetchEmbedInfoReducer } from './fetch-embed-info';
 
-export const reducer = (initial: State) => createReducer<State, Actions>(initial, {
-  ...checkAccessContextReducer(initial).handlers,
-  ...fetchAccessTokenReducer(initial).handlers,
-  ...fetchEmbedInfoReducer(initial).handlers,
-})
-
+export const reducer = (initial: State) =>
+    createReducer<State, Actions>(initial, {
+        ...checkAccessContextReducer(initial).handlers,
+        ...fetchAccessTokenReducer(initial).handlers,
+        ...fetchEmbedInfoReducer(initial).handlers,
+    });
 
 export default reducer;

--- a/src/components/data/PowerBI/Report/store/state.ts
+++ b/src/components/data/PowerBI/Report/store/state.ts
@@ -2,19 +2,21 @@ import { AccessToken, EmbedInfo } from '@equinor/fusion/lib/http/apiClients/mode
 import { Actions, ApiError } from './actions';
 
 export enum Status {
-  LoadingEmbedInfo,
-  AcquiringAccessToken,
-  AccessCheck,
+    LoadingEmbedInfo,
+    AcquiringAccessToken,
+    AccessCheck,
 }
 
 export type State = {
-  id: string,
-  status: Array<Status>,
-  errors: Array<ApiError>,
-  embedInfo?: EmbedInfo['embedConfig'],
-  token?: AccessToken,
-  hasContextAccess?: boolean,
-}
+    id: string;
+    status: Array<Status>;
+    errors: Array<ApiError>;
+    embedInfo?: EmbedInfo['embedConfig'];
+    token?: AccessToken;
+    hasContextAccess?: boolean;
+};
 
-export const removeStatus = (state: State, status: Status) => state.status.filter(x => x !== status);
-export const removeError = (state: State, action: Actions) => state.errors.filter(x => x.action.type !== action.type)
+export const removeStatus = (state: State, status: Status) =>
+    state.status.filter((x) => x !== status);
+export const removeError = (state: State, action: Actions) =>
+    state.errors.filter((x) => x.action.type !== action.type);

--- a/src/components/data/PowerBI/Report/store/store.ts
+++ b/src/components/data/PowerBI/Report/store/store.ts
@@ -3,28 +3,30 @@ import { EpicReducer, ActionPayload } from '@equinor/fusion/lib/epic';
 import { State } from './state';
 import { Actions, actions } from './actions';
 
-type CheckAccess = Pick<ActionPayload<typeof actions.checkContextAccess.request>, 'externalId' | 'type'>;
+type CheckAccess = Pick<
+    ActionPayload<typeof actions.checkContextAccess.request>,
+    'externalId' | 'type'
+>;
 
 export class Store extends EpicReducer<State, Actions> {
+    set contextAccess(value: boolean) {
+        this.dispatch(actions.setContextAccess(value));
+    }
 
-  set contextAccess(value: boolean) {
-    this.dispatch(actions.setContextAccess(value));
-  }
+    requestEmbedInfo(): VoidFunction {
+        this.dispatch(actions.fetchEmbedInfo.request(this.value.id));
+        return () => this.dispatch(actions.fetchEmbedInfo.cancel());
+    }
 
-  requestEmbedInfo(): VoidFunction {
-    this.dispatch(actions.fetchEmbedInfo.request(this.value.id));
-    return () => this.dispatch(actions.fetchEmbedInfo.cancel());
-  }
+    requestAccessToken(): VoidFunction {
+        this.dispatch(actions.fetchAccessToken.request(this.value.id));
+        return () => this.dispatch(actions.fetchAccessToken.cancel());
+    }
 
-  requestAccessToken(): VoidFunction {
-    this.dispatch(actions.fetchAccessToken.request(this.value.id));
-    return () => this.dispatch(actions.fetchAccessToken.cancel());
-  }
-
-  checkContextAccess(args: CheckAccess): VoidFunction {
-    this.dispatch(actions.checkContextAccess.request({ reportId: this.value.id, ...args }));
-    return () => this.dispatch(actions.checkContextAccess.cancel());
-  }
+    checkContextAccess(args: CheckAccess): VoidFunction {
+        this.dispatch(actions.checkContextAccess.request({ reportId: this.value.id, ...args }));
+        return () => this.dispatch(actions.checkContextAccess.cancel());
+    }
 }
 
 export default Store;

--- a/src/components/data/PowerBI/Report/store/store.ts
+++ b/src/components/data/PowerBI/Report/store/store.ts
@@ -6,7 +6,7 @@ import { Actions, actions } from './actions';
 type CheckAccess = Pick<
     ActionPayload<typeof actions.checkContextAccess.request>,
     'externalId' | 'type'
->;
+> & { silent?: boolean };
 
 export class Store extends EpicReducer<State, Actions> {
     set contextAccess(value: boolean) {
@@ -18,8 +18,10 @@ export class Store extends EpicReducer<State, Actions> {
         return () => this.dispatch(actions.fetchEmbedInfo.cancel());
     }
 
-    requestAccessToken(): VoidFunction {
-        this.dispatch(actions.fetchAccessToken.request(this.value.id));
+    requestAccessToken(silent?: boolean): VoidFunction {
+        this.dispatch(
+            actions.fetchAccessToken.request({ reportId: this.value.id, silent: !!silent })
+        );
         return () => this.dispatch(actions.fetchAccessToken.cancel());
     }
 

--- a/src/components/data/PowerBIReport/components/ReportErrorMessage/index.tsx
+++ b/src/components/data/PowerBIReport/components/ReportErrorMessage/index.tsx
@@ -30,9 +30,10 @@ const ReportErrorMessage: FC<ReportErrorMessageProps> = ({ report, contextErrorT
     const reportApiClient = useApiClients().report;
     const user = useCurrentUser();
     const timeStamp = useMemo(() => new Date().toString(), []);
-    const accessControlError = useMemo(() => contextErrorType !== 'MissingContextRelation', [
-        contextErrorType,
-    ]);
+    const accessControlError = useMemo(
+        () => contextErrorType !== 'MissingContextRelation',
+        [contextErrorType]
+    );
 
     const errorHeaderTitle = useMemo(() => {
         switch (contextErrorType) {


### PR DESCRIPTION
intial problem here was the checkContextAccess.
This was not reimplemented properly, and was run for all reports that implements the context.
but this service requres the report to also have RLS configuration.
Meaning all reports without RLS but who uses context, would fail the checkContextAccess check.

The fix for this turned out abit complicated, and also revealed some other minor issues. All should be adressed with this update.

checkAccessContext should only run if report "hasContext" and RLS.
To determine RLS, we need to fetch thee embedInfo.
This was previously not done until "hasContext" was set to true.
New routine always starts off getting the EmbedInfo.
On EmbedConfig change, we set HasRls accordingly.
When hasRls is set, we contiune to determined if we have contextAccess.
Where atlast the AccessToken request is fired when contextAccess is true.

This opened up more issues that has been resolved.
Unneceserry spinner on context switch.
When user changed context, checkContextAccess and requestAccessToken is run again. This caused a brief spinner on top of the report.
Added a silent mode to these request. So to not show spinner on subsequent request.

AccessTokenRequest forced report reload on context change.
When changing context, a new token was requested. This again forces the entire report to reload.
When hasContextAccess updated, it will only run if  hasContextAccess is true and no token is present.
The Report should no longer reload, and just filter itself in place as before.

Saved various files that was giving linting/formatting rule errors.