### PR TITLE
Org Chart Breadcrumb content prop

### DIFF
--- a/src/components/org/OrgChart/components/BreadCrumbs.tsx
+++ b/src/components/org/OrgChart/components/BreadCrumbs.tsx
@@ -58,6 +58,7 @@ const BreadCrumbs = () => {
                                 label={breadCrumb.label}
                                 id={breadCrumb.id}
                                 childId={breadCrumb.childId}
+                                content={breadCrumb.content}
                             />
                         )}
                     </foreignObject>

--- a/src/components/org/OrgChart/orgChartTypes.ts
+++ b/src/components/org/OrgChart/orgChartTypes.ts
@@ -38,4 +38,5 @@ export type BreadCrumb = {
     childId: string;
     label?: string;
     id?: string;
+    content?: JSX.Element;
 };


### PR DESCRIPTION
Added optional property **content: JSX.Element** to Breadcrumb. 
Then task owner icon, as described in user story below, can be added for Org Admin and Pro Org charts.
(In One Equinor app we will have opportunity to pass person photo to breadcrumb instead)

DevOps User Story:
[Org chart - Add icon for positions that are Task Owner ](https://statoil-proview.visualstudio.com/Fusion/_backlogs/backlog/Operations%20and%20Improvements/Stories/?showParents=true&workitem=17317)