### PR TITLE
chore: bump  z index for overlay

### DIFF
--- a/src/components/core/Root/styles.less
+++ b/src/components/core/Root/styles.less
@@ -51,7 +51,7 @@
         font-weight: 500;
     }
 
-    --overlay-z-index: 9991;
+    --overlay-z-index: 9994;
     --snacks-z-index: 9992;
     --dialog-z-index: 9993;
 


### PR DESCRIPTION
See linked issue for this PR.

Unsure what this might affect if some apps have used overlay, dialog, snacks DOM elements in a special way?