### PR TITLE
Powere BI - Reduced the reset rate for Token Refresh.

### DIFF
--- a/src/components/data/PowerBI/Report/store/epics/access-token.ts
+++ b/src/components/data/PowerBI/Report/store/epics/access-token.ts
@@ -11,7 +11,7 @@ import actions from '../actions/access';
 
 export type Dependencies = { clients: ApiClients };
 
-const refreshOffset = 60000;
+const refreshOffset = 58000;
 
 /**
  * Epic for access token


### PR DESCRIPTION
Reduced the reset rate for Token Refresh.
At 60 min it refresh after the token has already expired, and it fails.
Now runs after 58 min, in good time before it expires.
Should solve problem with report "disconneting" after 1 hour.