### PR TITLE
fix(usePeopleDetails): useEffectAsync

### DIFF
--- a/src/components/people/usePeopleDetails.ts
+++ b/src/components/people/usePeopleDetails.ts
@@ -24,7 +24,7 @@ export const usePeopleDetails = (personId?: string, person?: PersonDetails) => {
     }, []);
 
     useEffectAsync((signal) => {
-        if (!signal.abort && personId) {
+        if (!signal.aborted && personId) {
             fetchPersonData(personId);
         }
     }, [fetchPersonData, personId]);

--- a/src/components/people/usePeopleDetails.ts
+++ b/src/components/people/usePeopleDetails.ts
@@ -23,7 +23,7 @@ export const usePeopleDetails = (personId?: string, person?: PersonDetails) => {
         }
     }, []);
 
-    useEffectAsync((signal) => {
+    useEffectAsync(async (signal) => {
         if (!signal.aborted && personId) {
             fetchPersonData(personId);
         }

--- a/src/components/people/usePeopleDetails.ts
+++ b/src/components/people/usePeopleDetails.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { PersonDetails, useFusionContext } from '@equinor/fusion';
+import { PersonDetails, useEffectAsync, useFusionContext } from '@equinor/fusion';
 
 export const usePeopleDetails = (personId?: string, person?: PersonDetails) => {
     const [isFetching, setIsFetching] = useState(false);
@@ -23,8 +23,8 @@ export const usePeopleDetails = (personId?: string, person?: PersonDetails) => {
         }
     }, []);
 
-    useEffect(() => {
-        if (personId) {
+    useEffectAsync((signal) => {
+        if (!signal.abort && personId) {
             fetchPersonData(personId);
         }
     }, [fetchPersonData, personId]);


### PR DESCRIPTION
Updating to use the async `useEffectAsync` from the Fusion package when updating the state with person data, as not doing this can result in errors like
![image](https://user-images.githubusercontent.com/9586805/161813151-8a5a290b-b660-44eb-9bde-f7004212060d.png)
(here observed in the CPR app).

This change should mitigate the warning/error from React, as it no longer will attempt to perform state updates if the component becomes unmounted.

⚠️ This PR was generated by directly modifying the files in GitHub and I do not know if any tests (or other unknown side-effects) will be affected by this change.