### PR TITLE
Added min-height for header section. Remove height for rows

### DIFF
--- a/src/components/data/DataTable/styles.less
+++ b/src/components/data/DataTable/styles.less
@@ -57,6 +57,7 @@
             position: sticky;
             top: 0;
             z-index: 2;
+            min-height: calc(var(--grid-unit) * 6px);
 
             &.isSortable {
                 cursor: pointer;
@@ -119,10 +120,6 @@
     }
 
     &.comfortable {
-        .table {
-            --row-height-multiplier: 6px;
-        }
-
         .cell {
             --cell-horizontal-padding-multiplier: 2px;
         }

--- a/src/components/data/DataTable/styles.less
+++ b/src/components/data/DataTable/styles.less
@@ -27,6 +27,7 @@
 
             &.isClickable {
                 cursor: pointer;
+                min-height: 48px;
             }
 
             &.expand:not(.isExpandable),


### PR DESCRIPTION
Need to removed the hight for row.
Add the height for clickable tables.

With a lot of data in one cell: 
![image](https://user-images.githubusercontent.com/56077030/165751823-c3fe883d-2e96-4ca1-ab0c-d5ddf87e8576.png)

With one liner data: 
![image](https://user-images.githubusercontent.com/56077030/165751916-98f77414-ca4f-4987-ab1d-246fb35f42fd.png)
