### PR TITLE
Remove row-height compact mode

### DIFF
--- a/src/components/data/DataTable/styles.less
+++ b/src/components/data/DataTable/styles.less
@@ -1,7 +1,7 @@
 .container {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    min-height: calc(var(--grid-unit) * 6px);
     max-height: 100%;
     width: 100%;
     max-width: 100%;

--- a/src/components/data/DataTable/styles.less
+++ b/src/components/data/DataTable/styles.less
@@ -143,10 +143,6 @@
     }
 
     &.compact {
-        .table {
-            --row-height-multiplier: 4px;
-        }
-
         .cell {
             --cell-horizontal-padding-multiplier: 1px;
         }


### PR DESCRIPTION
I remove the row-height in this PR: https://github.com/equinor/fusion-components/pull/1481
But I forgot to remove it for compact mode as well.