### PR TITLE
!feat: remove scrollbar styling

### DIFF
--- a/src/components/core/Root/styles.less
+++ b/src/components/core/Root/styles.less
@@ -115,29 +115,29 @@
     z-index: var(--dialog-z-index);
 }
 
-:global {
-    ::-webkit-scrollbar {
-        width: calc(var(--grid-unit) * 0.5px);
-        height: calc(var(--grid-unit) * 1px);
-        overflow: visible;
-    }
+// :global {
+//     ::-webkit-scrollbar {
+//         width: calc(var(--grid-unit) * 0.5px);
+//         height: calc(var(--grid-unit) * 1px);
+//         overflow: visible;
+//     }
 
-    ::-webkit-scrollbar-track {
-        width: calc(var(--grid-unit) * 0.5px);
-        height: calc(var(--grid-unit) * 1px);
-        background: var(--color-black-alt4);
-    }
+//     ::-webkit-scrollbar-track {
+//         width: calc(var(--grid-unit) * 0.5px);
+//         height: calc(var(--grid-unit) * 1px);
+//         background: var(--color-black-alt4);
+//     }
 
-    ::-webkit-scrollbar-thumb {
-        background: var(--color-black-alt3);
-        border-radius: 100px;
+//     ::-webkit-scrollbar-thumb {
+//         background: var(--color-black-alt3);
+//         border-radius: 100px;
 
-        &:hover {
-            background: var(--color-black-alt2);
-        }
+//         &:hover {
+//             background: var(--color-black-alt2);
+//         }
 
-        &:active {
-            background: var(--color-primary-accent);
-        }
-    }
-}
+//         &:active {
+//             background: var(--color-primary-accent);
+//         }
+//     }
+// }


### PR DESCRIPTION
[26147](https://statoil-proview.visualstudio.com/Fusion%20Apps%20-%20Product%20Owners/_backlogs/backlog/Equinor%20Resource%20Management/Stories/?workitem=26147

**Copied from Description when changed from User Story to Bug**

The scroll bar on the right hand side is too narrow (invisible). Make the scroll bar wider so that it becomes visible.
Users working without mouse with scroll wheel, cannot find the scroll bar on the side of the windows.
Should be applied to all scroll bars across the apps.