### PR TITLE
Fix PersonCard re-render issue

### DIFF
--- a/src/components/people/usePeopleDetails.ts
+++ b/src/components/people/usePeopleDetails.ts
@@ -16,6 +16,7 @@ export const usePeopleDetails = (personId?: string, person?: PersonDetails) => {
             );
             setPersonDetails(response.data);
             setIsFetching(false);
+            setError(null);
         } catch (e) {
             setPersonDetails(null);
             setIsFetching(false);


### PR DESCRIPTION
Issue: _PersonCard_ does not re-render if you first provide an invalid _personId_, then later provide a valid _personId_.

Solution: Reset the error state when executing the try block.
