### PR TITLE
fix: Step props type no longer require 'stepPaneRef'

### DIFF
--- a/src/components/general/Stepper/Step.tsx
+++ b/src/components/general/Stepper/Step.tsx
@@ -19,7 +19,7 @@ type StepProps = {
     isLastStep?: boolean;
     stepCount?: number;
     verticalStep?: boolean;
-    stepPaneRef: MutableRefObject<HTMLElement>;
+    stepPaneRef?: MutableRefObject<HTMLElement>;
 };
 
 type BadgeProps = {


### PR DESCRIPTION
The 'stepPaneRef' was accidentally made non-optional in cd1797b0. This should be optional since the end-user use-case should not normally set this prop.