### PR TITLE
fix(MarkDownEditor): teardown only runs if editorRef current is present

### DIFF
--- a/src/components/general/MarkdownEditor/index.tsx
+++ b/src/components/general/MarkdownEditor/index.tsx
@@ -52,7 +52,7 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = (props: MarkdownEditorPro
         if (!editorRef.current) return;
         editorRef.current.addEventListener('change', onMarkdownChange);
         Object.assign(editorRef.current, attr);
-        return () => editorRef.current.removeEventListener('change', onMarkdownChange);
+        return () => editorRef?.current?.removeEventListener('change', onMarkdownChange);
     }, [editorRef]);
 
     return (


### PR DESCRIPTION
Fixing teardown on MarkdownEditor ref.
Closes #1448 