### PR TITLE
Fix: checking for invalid interval for overlapping dates

### DIFF
--- a/src/components/org/PositionTimeline/components/SplitSequence/index.tsx
+++ b/src/components/org/PositionTimeline/components/SplitSequence/index.tsx
@@ -23,6 +23,7 @@ export const SplitSequence: FC<SplitSequenceProps> = ({ rotationKey }) => {
     const styles = useStyles({ hasRotationGroups });
 
     const doesSplitOverlap = (split: TimelineSplit, splits: TimelineSplit[]): boolean => {
+				try {
         const intervalA = { start: new Date(split.appliesFrom), end: new Date(split.appliesTo) };
         const hasOverlap = splits
             .filter((s) => s.id !== split.id)
@@ -37,6 +38,10 @@ export const SplitSequence: FC<SplitSequenceProps> = ({ rotationKey }) => {
                 return aOverlapsB || bOverlapsA;
             });
         return hasOverlap;
+		} catch {
+				// invalid date interval (toDate before fromDate) == self overlap
+				return true;
+		}
     };
 
     return (


### PR DESCRIPTION
Overlapping indication on timline preview for position splits can have from date after to date and vice verca.
This invalid interval will cause error. This is a fix for this.