### PR TITLE
feat(FusionHeader): removing reference to headercontent so apps can u…

### DIFF
--- a/src/components/core/Header/index.tsx
+++ b/src/components/core/Header/index.tsx
@@ -54,7 +54,7 @@ const FusionHeader: FC<FusionHeaderProps> = ({
     showSettings,
 }) => {
     const {
-        refs: { headerContent, headerAppAside },
+        refs: { headerAppAside },
     } = useFusionContext();
     const currentApp = useCurrentApp();
 
@@ -91,10 +91,7 @@ const FusionHeader: FC<FusionHeaderProps> = ({
                     </>
                 )}
             </div>
-            <div
-                className={styles.contentContainer}
-                ref={headerContent as MutableRefObject<HTMLDivElement | null>}
-            >
+            <div className={styles.contentContainer}>
                 {content && createElement(content, { app: currentApp })}
             </div>
 


### PR DESCRIPTION
FusionHeader components no longer uses reference to headercontent, so apps can use portals contextSelector.

BREAKING CHANGE: for use on portal with new Fusion-framework and updated ContextSelector. if used on current portal the context selector will not show up.