### PR TITLE
NavigationDrawer - Hover and onClick improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion-components",
-    "version": "2.10.2",
+    "version": "2.10.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion-components",
-    "version": "2.10.2",
+    "version": "2.10.3",
     "description": "Common react components used by fusion core and fusion apps",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/src/components/general/NavigationDrawer/components/Components.style.ts
+++ b/src/components/general/NavigationDrawer/components/Components.style.ts
@@ -117,6 +117,10 @@ export const useStyles = makeStyles(
                     )})`,
                 },
 
+                '&$noHoverContainer': {
+                    pointerEvents: 'none !important',
+                },
+
                 '&$isActive': {
                     color: `var(--sidebar-isActiveTextColor, ${theme.colors.infographic.primary__moss_green_100.getVariable(
                         'color'
@@ -244,6 +248,7 @@ export const useStyles = makeStyles(
                 width: 'calc(var(--grid-unit) * 40px + 1px)',
                 paddingBottom: 'calc(var(--grid-unit) * 5px)',
             },
+            noHoverContainer: {},
             linkContainer: {},
             toggleOpenContainer: {},
             asideContainer: {},

--- a/src/components/general/NavigationDrawer/components/Grouping.tsx
+++ b/src/components/general/NavigationDrawer/components/Grouping.tsx
@@ -26,7 +26,7 @@ const Grouping: FC<NavigationComponentProps> = ({
         isDisabled,
         href,
         info,
-				style
+        style,
     } = navigationItem;
     const styles = useStyles();
     const [shouldHaveTooltip, setShouldHaveTooltip] = useState(false);
@@ -50,7 +50,11 @@ const Grouping: FC<NavigationComponentProps> = ({
     );
 
     const change = useCallback(() => {
-        onChange && onChange(id, !isOpen, !isDisabled);
+        //If no onClick function is defined the grouping should toggle open on the whole container and not toggle active.
+        const shouldToggleOpen = onClick ? !isOpen : true;
+        const shouldToggleActive = onClick ? !isDisabled : false;
+
+        onChange && onChange(id, shouldToggleOpen, shouldToggleActive);
         !isDisabled && onClick && onClick();
     }, [onClick, id, isOpen, onChange, isDisabled]);
 
@@ -96,6 +100,7 @@ const Grouping: FC<NavigationComponentProps> = ({
                 groupingComponent={getNavigationContent}
                 isActive={isActive}
                 darkTheme={darkTheme}
+                groupShouldNotBeClickable={!onClick}
             />
         ),
         [icon, navigationStructure, getNavigationContent, navigationChildren, isActive]
@@ -114,7 +119,7 @@ const Grouping: FC<NavigationComponentProps> = ({
                 isCollapsed={isCollapsed}
                 isDisabled={isDisabled}
                 info={info}
-								style={style}
+                style={style}
             >
                 {navigationContent}
             </NavigationItem>

--- a/src/components/general/NavigationDrawer/components/NavigationItem.tsx
+++ b/src/components/general/NavigationDrawer/components/NavigationItem.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { FC } from 'react';
 import { useAnchor, UseAnchorProps } from '../../ApplicationGuidance';
 import { useStyles } from './Components.style';
 
@@ -11,10 +12,11 @@ type NavigationItemProps = {
     onClick?: () => void;
     isDisabled?: boolean;
     info?: UseAnchorProps;
-		style?: React.CSSProperties;
+    style?: React.CSSProperties;
+    noHoverContainer?: boolean;
 };
 
-const NavigationItem = ({
+const NavigationItem: FC<NavigationItemProps> = ({
     id,
     children,
     isActive,
@@ -23,10 +25,13 @@ const NavigationItem = ({
     onClick,
     isDisabled,
     info,
-		style,
+    style,
+    noHoverContainer,
 }: NavigationItemProps) => {
     const styles = useStyles();
+
     const containerClassNames = classNames(styles.container, {
+        [styles.noHoverContainer]: noHoverContainer,
         [styles.isActive]: isActive,
         [styles.isCollapsed]: isCollapsed,
         [styles.menuSection]: type === 'section',
@@ -37,7 +42,13 @@ const NavigationItem = ({
     const anchorRef = useAnchor<HTMLDivElement>(info);
 
     return (
-        <div id={id} style={style} className={containerClassNames} onClick={onClick} ref={anchorRef}>
+        <div
+            id={id}
+            style={style}
+            className={containerClassNames}
+            onClick={onClick}
+            ref={anchorRef}
+        >
             {children}
             <div className={styles.visualOnClickContainer} />
         </div>

--- a/src/components/general/NavigationDrawer/components/NavigationPopover.tsx
+++ b/src/components/general/NavigationDrawer/components/NavigationPopover.tsx
@@ -1,4 +1,4 @@
-import { useRef, ReactNode, useState, useCallback } from 'react';
+import { useRef, ReactNode, useState, useCallback, FC } from 'react';
 import {
     RelativeOverlayPortal,
     useClickOutsideOverlayPortal,
@@ -20,15 +20,17 @@ type NavigationPopoverProps = {
     navigationChildren?: NavigationStructure[];
     groupingComponent?: () => JSX.Element;
     darkTheme?: boolean;
+    groupShouldNotBeClickable?: boolean;
 };
 
-const NavigationPopover = ({
+const NavigationPopover: FC<NavigationPopoverProps> = ({
     icon,
     navigationStructure,
     groupingComponent,
     isActive,
     navigationChildren,
     darkTheme,
+    groupShouldNotBeClickable,
 }: NavigationPopoverProps) => {
     const styles = useStyles();
     const [isOpen, setIsOpen] = useState(false);
@@ -54,7 +56,12 @@ const NavigationPopover = ({
 
             <RelativeOverlayPortal relativeRef={iconRef} show={isOpen}>
                 <div className={popoverClassNames} onClick={close}>
-                    <NavigationItem type="grouping" isActive={isActive} isCollapsed={false}>
+                    <NavigationItem
+                        type="grouping"
+                        isActive={isActive}
+                        isCollapsed={false}
+                        noHoverContainer={groupShouldNotBeClickable}
+                    >
                         {groupingComponent && groupingComponent()}
                     </NavigationItem>
                     {navigationStructure}

--- a/src/components/general/NavigationDrawer/components/Section.tsx
+++ b/src/components/general/NavigationDrawer/components/Section.tsx
@@ -42,9 +42,16 @@ const Section: FC<NavigationComponentProps> = ({ navigationItem, onChange, isCol
     );
 
     const change = useCallback(() => {
-        onChange && onChange(id, !isOpen, !isDisabled);
+        //If no onClick function is defined the section should toggle open on the whole container and not toggle active.
+        const shouldToggleOpen = onClick ? !isOpen : true;
+        const shouldToggleActive = onClick ? !isDisabled : false;
+
+        onChange && onChange(id, shouldToggleOpen, shouldToggleActive);
         !isDisabled && onClick && onClick();
     }, [onClick, id, isOpen, onChange, isDisabled]);
+
+    //Collapsed sections with no onClick defined should not be hoverable
+    const noHoverContainer = !onClick && isCollapsed;
 
     return (
         <>
@@ -55,6 +62,7 @@ const Section: FC<NavigationComponentProps> = ({ navigationItem, onChange, isCol
                 isDisabled={isDisabled}
                 info={info}
                 style={style}
+                noHoverContainer={noHoverContainer}
             >
                 <div className={styles.sectionContainer} ref={tooltipRef}>
                     <a


### PR DESCRIPTION
Sections and groupings without a navigation action should not be hoverable in the navigation popover.
If navigation drawer is not collapsed, sections and groupings without a navigation action should show/hide children when clicking anywhere on the item, not just the arrow. 