### PR TITLE
Fix: NavigationDrawer Hover on child items with custom background color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion-components",
-    "version": "2.10.4",
+    "version": "2.10.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion-components",
-    "version": "2.10.4",
+    "version": "2.10.5",
     "description": "Common react components used by fusion core and fusion apps",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/src/components/general/NavigationDrawer/components/Components.style.ts
+++ b/src/components/general/NavigationDrawer/components/Components.style.ts
@@ -111,7 +111,7 @@ export const useStyles = makeStyles(
                 '&:hover': {
                     backgroundColor: `var(--sidebar-hoverBackgroundColor, ${theme.colors.interactive.primary__hover_alt.getVariable(
                         'color'
-                    )})`,
+                    )}) !important`,
                     color: `var(--sidebar-hoverTextColor, ${theme.colors.interactive.primary__hover.getVariable(
                         'color'
                     )})`,


### PR DESCRIPTION
If a child item in navigationdrawer has a custom background color it overrides the background set on hover. 
Added !important to backgroundColor on hover style to prevent this.