### PR TITLE
Fix overflow for datatable

### DIFF
--- a/src/components/data/DataTable/styles.less
+++ b/src/components/data/DataTable/styles.less
@@ -10,6 +10,7 @@
         flex-grow: 1;
         width: 100%;
         display: grid;
+        overflow: auto;
         --border-color: var(--color-black-alt4);
 
         .cell {


### PR DESCRIPTION
Add overflow for DataTable.
Sticky paginator.

For sticky headers, add:
```
<div style={{overflow: "hidden"}}>
<DataTable/>
 </div>
```