### PR TITLE
Fix/ position card pmt external styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/fusion-components",
-    "version": "2.12.3",
+    "version": "2.12.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/fusion-components",
-            "version": "2.13.0",
+            "version": "2.12.4",
             "license": "MIT",
             "dependencies": {
                 "@equinor/fusion-components": "file:.yalc/@equinor/fusion-components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion-components",
-    "version": "2.12.3",
+    "version": "2.12.4",
     "description": "Common react components used by fusion core and fusion apps",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/src/components/org/PositionCard/components/PositionIconPhoto.tsx
+++ b/src/components/org/PositionCard/components/PositionIconPhoto.tsx
@@ -46,7 +46,7 @@ const PositionPhotoIcon: FC<PositionPhotoIconProps> = ({
     const isPmt = position.isProjectManagementTeam && showPmt;
 
     //show pmt as warning if allowExternalProjectManagementTeam is not enabled but non employee is assigned regardless
-    const pmtExternalWarning =
+    const pmtExternalIndication =
         isPmt &&
         !(position.properties as Record<string, unknown>).allowExternalProjectManagementTeam &&
         currentInstance.assignedPerson &&
@@ -56,11 +56,10 @@ const PositionPhotoIcon: FC<PositionPhotoIconProps> = ({
     const linkedRef = useTooltipRef('Linked', 'below');
     const rotatingRef = useTooltipRef('Rotating', 'below');
 
-    const pmtTooltip = pmtExternalWarning ? (
+    const pmtTooltip = pmtExternalIndication ? (
         <p>
-            {' '}
             PMT role is not enabled for external personnel on this position.
-            <br /> You can turn on this setting while editing the position.{' '}
+            <br /> You can turn on this setting while editing the position.
         </p>
     ) : (
         <p>
@@ -126,14 +125,9 @@ const PositionPhotoIcon: FC<PositionPhotoIconProps> = ({
                     )}
                     {isPmt && (
                         <span ref={pmtRef}>
-                            {pmtExternalWarning ? (
-                                <div className={styles.pmtWarning}>
-                                    <s className={styles.pmtText}>PMT</s>
-                                    <ErrorIcon outline />{' '}
-                                </div>
-                            ) : (
-                                <p className={styles.pmtText}>PMT</p>
-                            )}
+                            <p className={styles.pmtText}>
+                                {pmtExternalIndication ? '(PMT)' : 'PMT'}
+                            </p>
                         </span>
                     )}
                 </div>

--- a/src/components/org/PositionCard/styles.less
+++ b/src/components/org/PositionCard/styles.less
@@ -118,21 +118,7 @@
 								  font-size: 11px;
 								  font-weight: 700;
 								  line-height: 16px;
-							}
-							.pmtWarning {
-								s {
-									color: #B30D2F;
-								}
-								display: flex;
-								flex-direction: row;
-								align-items: center;
-								gap: 2px;
-
-								svg {
-									color: #B30D2F;
-								}
-							}
-
+						}
             .stateIcons {
                 position: relative;
                 padding-top: calc(var(--grid-unit) * 1px);


### PR DESCRIPTION
Org/position card.

The indication if allocated person was external and external setting was not set, was too scary. So now adjusted to only show PMT in parentheses instead.